### PR TITLE
update CUDA easyblock for v6.x

### DIFF
--- a/easybuild/easyblocks/__init__.py
+++ b/easybuild/easyblocks/__init__.py
@@ -33,7 +33,7 @@ from pkgutil import extend_path
 
 # note: release candidates should be versioned as a pre-release, e.g. "1.1rc1"
 # 1.1-rc1 would indicate a post-release, i.e., and update of 1.1, so beware
-VERSION = LooseVersion("1.15.1dev")
+VERSION = LooseVersion("1.16.0dev")
 UNKNOWN = "UNKNOWN"
 
 

--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -81,14 +81,14 @@ class EB_CUDA(Binary):
 
         chk_libdir = ["lib64"]
         
-# Versions higher than 6 do not provide 32 bit libraries
+        # Versions higher than 6 do not provide 32 bit libraries
         if LooseVersion(self.version) < LooseVersion("6"):
             chk_libdir += ["lib"]
 
         custom_paths = {
             'files': ["bin/%s" % x for x in ["fatbinary", "nvcc", "nvlink", "ptxas"]] +
                      ["%s/lib%s.so" % (x, y) for x in chk_libdir for y in ["cublas", "cudart", "cufft",
-                                                                                 "curand", "cusparse"]] +
+                                                                           "curand", "cusparse"]] +
                      ["open64/bin/nvopencc"],
             'dirs': ["include"],
         }

--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -79,9 +79,15 @@ class EB_CUDA(Binary):
     def sanity_check_step(self):
         """Custom sanity check for CUDA."""
 
+        chk_libdir = ["lib64"]
+        
+# Versions higher than 6 do not provide 32 bit libraries
+        if LooseVersion(self.version) < LooseVersion("6"):
+            chk_libdir += ["lib"]
+
         custom_paths = {
             'files': ["bin/%s" % x for x in ["fatbinary", "nvcc", "nvlink", "ptxas"]] +
-                     ["%s/lib%s.so" % (x, y) for x in ["lib", "lib64"] for y in ["cublas", "cudart", "cufft",
+                     ["%s/lib%s.so" % (x, y) for x in chk_libdir for y in ["cublas", "cudart", "cufft",
                                                                                  "curand", "cusparse"]] +
                      ["open64/bin/nvopencc"],
             'dirs': ["include"],


### PR DESCRIPTION
Versions higher than 6 do not provide 32 bit libraries