### PR TITLE
Julia

### DIFF
--- a/easybuild/easyblocks/j/julia.py
+++ b/easybuild/easyblocks/j/julia.py
@@ -1,0 +1,29 @@
+from easybuild.framework.easyconfig import CUSTOM, MANDATORY, BUILD
+from easybuild.tools.filetools import run_cmd
+from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.config import source_paths
+from easybuild.tools.filetools import mkdir
+import os, os.path
+
+class Julia(ConfigureMake):
+
+    def configure_step(self):
+        
+        srcpath = os.path.join(source_paths()[0], self.name[0].lower(), self.name, 'deps')
+	#mkdir(srcpath, parents=True)
+        prefix = self.installdir
+        configopts = self.cfg['configopts']
+
+        f = open('Make.user', 'a')
+        f.write("""
+prefix=%(prefix)s
+
+# Use libraries available on the system instead of building them
+
+%(configopts)s
+
+""" % vars())
+        f.close()
+        # check no self.cfg['preconfigopts'] etc are set
+
+EB_Julia = Julia

--- a/easybuild/easyblocks/j/julia.py
+++ b/easybuild/easyblocks/j/julia.py
@@ -5,15 +5,14 @@ from easybuild.tools.config import source_paths
 from easybuild.tools.filetools import mkdir
 import os, os.path
 
-class Julia(ConfigureMake):
+class EB_Julia(ConfigureMake):
 
     def configure_step(self):
-        
+        # Writing a Make.user file, as recommended in the Julia documentation
         srcpath = os.path.join(source_paths()[0], self.name[0].lower(), self.name, 'deps')
-	#mkdir(srcpath, parents=True)
         prefix = self.installdir
+        assert not self.cfg['preconfigopts'], "preconfigopts not supported for Julia"
         configopts = self.cfg['configopts']
-
         f = open('Make.user', 'a')
         f.write("""
 prefix=%(prefix)s
@@ -24,6 +23,3 @@ prefix=%(prefix)s
 
 """ % vars())
         f.close()
-        # check no self.cfg['preconfigopts'] etc are set
-
-EB_Julia = Julia


### PR DESCRIPTION
An easyblock for Julia, which has not configure script.  prebuildopts and buildopts didn't work for me, so this easy block does what the Juila documentation says to do and writes a Make.user file.  I use it with an easyconfig which includes:

configopts = """
USE_SYSTEM_BLAS=1
USE_SYSTEM_LAPACK=1
USE_SYSTEM_FFTW=1
"""
