### PR TITLE
move support for staged_install from CPLEX easyblock to generic Binary easyblock

### DIFF
--- a/easybuild/easyblocks/c/cplex.py
+++ b/easybuild/easyblocks/c/cplex.py
@@ -93,6 +93,7 @@ class EB_CPLEX(Binary):
 
     def post_install_step(self):
         """Determine bin directory for this CPLEX installation."""
+        # handle staged install via Binary parent class
         super(EB_CPLEX, self).post_install_step()
 
         # determine bin dir

--- a/easybuild/easyblocks/c/cplex.py
+++ b/easybuild/easyblocks/c/cplex.py
@@ -53,14 +53,6 @@ class EB_CPLEX(Binary):
         super(EB_CPLEX, self).__init__(*args, **kwargs)
         self.bindir = None
 
-    @staticmethod
-    def extra_options():
-        extra_vars = [
-            # staged install via a tmp dir can help with the hard (potentially faulty) check on available disk space
-            ('staged_install', [False, "Should the installation should be staged via a temporary dir?", CUSTOM]),
-        ]
-        return Binary.extra_options(extra_vars)
-
     def install_step(self):
         """CPLEX has an interactive installer, so use Q&A"""
 
@@ -78,16 +70,12 @@ class EB_CPLEX(Binary):
 
         cmd = "%s -i console" % dst
 
-        install_target = self.installdir
-        if self.cfg['staged_install']:
-            install_target = stagedir
-
         qanda = {
             "PRESS <ENTER> TO CONTINUE:": '',
             'Press Enter to continue viewing the license agreement, or enter' \
             ' "1" to accept the agreement, "2" to decline it, "3" to print it,' \
             ' or "99" to go back to the previous screen.:': '1',
-            'ENTER AN ABSOLUTE PATH, OR PRESS <ENTER> TO ACCEPT THE DEFAULT :': install_target,
+            'ENTER AN ABSOLUTE PATH, OR PRESS <ENTER> TO ACCEPT THE DEFAULT :': self.installdir,
             'IS THIS CORRECT? (Y/N):': 'y',
             'PRESS <ENTER> TO INSTALL:': '',
             "PRESS <ENTER> TO EXIT THE INSTALLER:": '',
@@ -98,19 +86,14 @@ class EB_CPLEX(Binary):
 
         run_cmd_qa(cmd, qanda, no_qa=noqanda, log_all=True, simple=True)
 
-        if self.cfg['staged_install']:
-            # move staged installation to actual install dir
-            try:
-                # copytree expects target directory to not exist yet
-                shutil.rmtree(self.installdir)
-                shutil.copytree(stagedir, self.installdir)
-            except OSError, err:
-                self.log.error("Failed to move staged install from %s to %s: %s" % (stagedir, self.installdir, err))
-
         try:
             os.chmod(self.installdir, stat.S_IRWXU | stat.S_IXOTH | stat.S_IXGRP | stat.S_IROTH | stat.S_IRGRP)
         except OSError, err:
             self.log.exception("Can't set permissions on %s: %s" % (self.installdir, err))
+
+    def post_install_step(self):
+        """Determine bin directory for this CPLEX installation."""
+        super(EB_CPLEX, self).post_install_step()
 
         # determine bin dir
         os.chdir(self.installdir)
@@ -135,10 +118,8 @@ class EB_CPLEX(Binary):
 
     def sanity_check_step(self):
         """Custom sanity check for CPLEX"""
-
         custom_paths = {
             'files':["%s/%s" % (self.bindir, x) for x in ["convert", "cplex", "cplexamp"]],
             'dirs':[],
         }
-
         super(EB_CPLEX, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/generic/binary.py
+++ b/easybuild/easyblocks/generic/binary.py
@@ -115,7 +115,7 @@ class Binary(EasyBlock):
             try:
                 # copytree expects target directory to not exist yet
                 if os.path.exists(self.installdir):
-                    shutil.rmtree(self.installdir)
+                    rmtree2(self.installdir)
                 shutil.copytree(staged_installdir, self.installdir)
             except OSError, err:
                 tup = (staged_installdir, self.installdir, err)

--- a/easybuild/easyblocks/generic/binary.py
+++ b/easybuild/easyblocks/generic/binary.py
@@ -38,7 +38,7 @@ import stat
 
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
-from easybuild.tools.filetools import run_cmd, rmtree2
+from easybuild.tools.filetools import mkdir, run_cmd, rmtree2
 
 
 class Binary(EasyBlock):
@@ -53,8 +53,21 @@ class Binary(EasyBlock):
         extra_vars = dict(EasyBlock.extra_options(extra_vars))
         extra_vars.update({
             'install_cmd': [None, "Install command to be used.", CUSTOM],
+            # staged installation can help with the hard (potentially faulty) check on available disk space
+            'staged_install': [False, "Perform staged installation via subdirectory of build directory", CUSTOM],
         })
         return EasyBlock.extra_options(extra_vars)
+
+    def __init__(self, *args, **kwargs):
+        """Initialize Binary-specific variables."""
+        super(Binary, self).__init__(*args, **kwargs)
+
+        self.actual_installdir = None
+        if self.cfg['staged_install']:
+            self.actual_installdir = self.installdir
+            self.installdir = os.path.join(self.builddir, 'staged')
+            mkdir(self.installdir, parents=True)
+            self.log.info("Performing staged installation via %s" % self.installdir)
 
     def extract_step(self):
         """Move all source files to the build directory"""
@@ -91,6 +104,21 @@ class Binary(EasyBlock):
         else:
             self.log.info("Installing %s using command '%s'..." % (self.name, self.cfg['install_cmd']))
             run_cmd(self.cfg['install_cmd'], log_all=True, simple=True)
+
+    def post_install_step(self):
+        """Copy installation to actual installation directory in case of a staged installation."""
+        if self.cfg['staged_install']:
+            staged_installdir = self.installdir
+            self.installdir = self.actual_installdir
+            try:
+                # copytree expects target directory to not exist yet
+                shutil.rmtree(self.installdir)
+                shutil.copytree(staged_installdir, self.installdir)
+            except OSError, err:
+                tup = (staged_installdir, self.installdir, err)
+                self.log.error("Failed to move staged install from %s to %s: %s" % tup)
+
+        super(Binary, self).post_install_step()
 
     def make_module_extra(self):
         """Add the install directory to the PATH."""

--- a/easybuild/easyblocks/generic/binary.py
+++ b/easybuild/easyblocks/generic/binary.py
@@ -112,7 +112,8 @@ class Binary(EasyBlock):
             self.installdir = self.actual_installdir
             try:
                 # copytree expects target directory to not exist yet
-                shutil.rmtree(self.installdir)
+                if os.path.exists(self.installdir):
+                    shutil.rmtree(self.installdir)
                 shutil.copytree(staged_installdir, self.installdir)
             except OSError, err:
                 tup = (staged_installdir, self.installdir, err)

--- a/easybuild/easyblocks/generic/rpm.py
+++ b/easybuild/easyblocks/generic/rpm.py
@@ -41,7 +41,6 @@ from os.path import expanduser
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.binary import Binary
-from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.filetools import run_cmd
 
@@ -62,14 +61,14 @@ class Rpm(Binary):
     @staticmethod
     def extra_options(extra_vars=None):
         """Extra easyconfig parameters specific to RPMs."""
-        extra_vars = dict(EasyBlock.extra_options(extra_vars))
+        extra_vars = dict(Binary.extra_options(extra_vars))
         extra_vars.update({
             'force': [False, "Use force", CUSTOM],
             'preinstall': [False, "Enable pre install", CUSTOM],
             'postinstall': [False, "Enable post install", CUSTOM],
             'makesymlinks': [[], "Create symlinks for listed paths", CUSTOM],  # supports glob
         })
-        return EasyBlock.extra_options(extra_vars)
+        return Binary.extra_options(extra_vars)
 
     def configure_step(self):
         """Custom configuration procedure for RPMs: rebuild RPMs for relocation if required."""


### PR DESCRIPTION
that way, the staged install option is also available for other easyblocks that derive from `Binary` (e.g. for ABAQUS, which triggered this PR), and for easyconfigs that use `Binary` directly