### PR TITLE
GCC LTO cleanup

### DIFF
--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -525,7 +525,7 @@ class EB_GCC(ConfigureMake):
             bin_files.append('gfortran')
             lib_files.extend(['libgfortran.%s' % sharedlib_ext, 'libgfortran.a'])
 
-        if 'lto' in self.cfg['languages']:
+        if self.cfg['withlto']:
             libexec_files.extend(['lto1', 'lto-wrapper'])
             if os_type in ['Linux']:
                 libexec_files.append('liblto_plugin.%s' % sharedlib_ext)


### PR DESCRIPTION
GCC's LTO support is controlled via the custom `withlto` easyconfig parameter -- and so should be the corresponding sanity check.
