### PR TITLE
remove fes from CP2K sanity check

### DIFF
--- a/easybuild/easyblocks/c/cp2k.py
+++ b/easybuild/easyblocks/c/cp2k.py
@@ -774,7 +774,7 @@ class EB_CP2K(EasyBlock):
 
         cp2k_type = self.cfg['type']
         custom_paths = {
-            'files': ["bin/%s.%s" % (x, cp2k_type) for x in ["cp2k", "cp2k_shell", "fes"]],
+            'files': ["bin/%s.%s" % (x, cp2k_type) for x in ["cp2k", "cp2k_shell"]],
             'dirs': ["tests"]
         }
 


### PR DESCRIPTION
remove `fes` from sanity check, since it's not really part of CP2K (and is no longer there in CP2K v2.6.0)