### PR TITLE
Fix/suitesparse

### DIFF
--- a/easybuild/easyblocks/s/suitesparse.py
+++ b/easybuild/easyblocks/s/suitesparse.py
@@ -94,11 +94,10 @@ class EB_SuiteSparse(ConfigureMake):
         try:
             for line in fileinput.input(fp, inplace=1, backup='.orig'):
                 for (var, val) in cfgvars.items():
-                    # varaibles in cfgvars that have not been substituted
-                    # here will have to be appended to the end of the file,
-                    # so those substituted should be removed from cfgvars
-                    # if a line was modified
                     orig_line = line
+                    # for variables in cfgvars, substiture lines assignment 
+                    # in the file, whatever they are, by assignments to the
+                    # values in cfgvars
                     line = re.sub(r"^\s*(%s\s*=\s*).*$" % var,
                                   r"\1 %s # patched by EasyBuild" % val,
                                   line)

--- a/easybuild/easyblocks/s/suitesparse.py
+++ b/easybuild/easyblocks/s/suitesparse.py
@@ -94,8 +94,12 @@ class EB_SuiteSparse(ConfigureMake):
         try:
             for line in fileinput.input(fp, inplace=1, backup='.orig'):
                 for (k, v) in cfgvars.items():
-                    line = re.sub(r"^(%s\s*=\s*).*$" % k, r"\1 %s # patched by EasyBuild" % v, line)
-                    if k in line:
+                    orig_line = line
+                    line = re.sub(r"^\s*(%s\s*=\s*).*$" % k,
+                                  r"\1 %s # patched by EasyBuild" % v,
+                                  line)
+                    if line != orig_line:
+# Note: this will crash & burn in Python 3
                         cfgvars.pop(k)
                 sys.stdout.write(line)
         except IOError, err:


### PR DESCRIPTION
Fixed two problems with this easyblock:
1) it assumes variable definitions in the .mk file will not have leading whitespace (assumption doesn't hold for SuiteSparse 4.4.3),
2) the mechanism for ensuring that all variables not replaced in the .mk file are appended works only if the variable name does not occur in any line (e.g., comment) prior to its definition (definitely not the case in SuiteSparse 4.4.3).

Although the current code works, it is not future proof.  In Python 2, the items() method returns a list of key/value tuples, hence it is save to apply the pop() method to the cfgvars dictionary.  In Python 3, the items() method will return an iterator, and removing items from a data structure one is iterating over is not a good idea.
I've only added a comment, since I assume that this pattern will be quite pervasive given the list of authors of this block, so it should probably be addressed more systematically.