### PR TITLE
add new generic easyblock for installing a bundle of modules

### DIFF
--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -54,6 +54,9 @@ class Bundle(EasyBlock):
 
     def sanity_check_step(self):
         """
-        Nothing is being installed, so nothing to sanity check on
+        Nothing is being installed, so just being able to load the (fake) module is sufficient
         """
-        pass
+        self.log.info("Testing loading of module '%s' by means of sanity check" % self.full_mod_name)
+        fake_mod_data = self.load_fake_module(purge=True)
+        self.log.debug("Cleaning up after testing loading of module")
+        self.clean_up_fake_module(fake_mod_data)

--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -23,7 +23,7 @@
 # along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
 ##
 """
-EasyBuild support for installing compiler toolchains, implemented as an easyblock
+EasyBuild support for installing a bundle of modules, implemented as a generic easyblock
 
 @author: Stijn De Weirdt (Ghent University)
 @author: Dries Verdegem (Ghent University)
@@ -32,11 +32,28 @@ EasyBuild support for installing compiler toolchains, implemented as an easybloc
 @author: Jens Timmerman (Ghent University)
 """
 
-from easybuild.easyblocks.generic.bundle import Bundle
+from easybuild.framework.easyblock import EasyBlock
 
 
-class Toolchain(Bundle):
+class Bundle(EasyBlock):
     """
-    Compiler toolchain: generate module file only, nothing to build/install
+    Bundle of modules: only generate module files, nothing to build/install
     """
-    pass
+
+    def configure_step(self):
+        """Do nothing."""
+        pass
+
+    def build_step(self):
+        """Do nothing."""
+        pass
+
+    def install_step(self):
+        """Do nothing."""
+        pass
+
+    def sanity_check_step(self):
+        """
+        Nothing is being installed, so nothing to sanity check on
+        """
+        pass


### PR DESCRIPTION
this has been talked over a lot, but never got looked into

`Bundle` should be used for anything that's just a (drumroll) bundle of modules, without any additional meaning; examples include the HPCBIOS bundles (e.g., https://github.com/hpcugent/easybuild-easyconfigs/tree/master/easybuild/easyconfigs/h/HPCBIOS_LifeSciences); @fgeorgatos: up for tackling that once this gets merged?

toolchains should still use the `Toolchain` which is now reworked on top of `Bundle`, since it does have additional meaning and I expect the `Toolchain` generic easyblock to do more than just bundle things together in the feature (e.g. potentially defining things like `$CC`, etc., probably with `pushenv`)