### PR TITLE
Make Score-P easyblock usable for subtoolchains w/o MPI

### DIFF
--- a/easybuild/easyblocks/s/score_p.py
+++ b/easybuild/easyblocks/s/score_p.py
@@ -27,6 +27,7 @@ EasyBuild support for software using the Score-P configuration style, implemente
 
 @author: Kenneth Hoste (Ghent University)
 @author: Bernd Mohr (Juelich Supercomputing Centre)
+@author: Markus Geimer (Juelich Supercomputing Centre)
 """
 import os
 
@@ -61,10 +62,11 @@ class EB_Score_minus_P(ConfigureMake):
             toolchain.MPICH2: 'mpich2',
         }
         mpi_fam = self.toolchain.mpi_family()
-        if mpi_fam in mpi_opts:
-            self.cfg.update('configopts', "--with-mpi=%s" % mpi_opts[mpi_fam])
-        else:
-            self.log.error("MPI family %s not supported yet (only: %s)" % (mpi_fam, ', '.join(mpi_opts.keys())))
+        if mpi_fam is not None:
+            if mpi_fam in mpi_opts:
+                self.cfg.update('configopts', "--with-mpi=%s" % mpi_opts[mpi_fam])
+            else:
+                self.log.error("MPI family %s not supported yet (only: %s)" % (mpi_fam, ', '.join(mpi_opts.keys())))
 
         # auto-detection for dependencies mostly works fine, but hard specify paths anyway to have full control
         deps = {

--- a/easybuild/easyblocks/s/score_p.py
+++ b/easybuild/easyblocks/s/score_p.py
@@ -68,7 +68,8 @@ class EB_Score_minus_P(ConfigureMake):
             if mpi_fam in mpi_opts:
                 self.cfg.update('configopts', "--with-mpi=%s" % mpi_opts[mpi_fam])
             else:
-                self.log.error("MPI family %s not supported yet (only: %s)" % (mpi_fam, ', '.join(mpi_opts.keys())))
+                raise EasyBuildError("MPI family %s not supported yet (only: %s)",
+                                     mpi_fam, ', '.join(mpi_opts.keys()))
 
         # auto-detection for dependencies mostly works fine, but hard specify paths anyway to have full control
         deps = {

--- a/easybuild/easyblocks/s/score_p.py
+++ b/easybuild/easyblocks/s/score_p.py
@@ -77,6 +77,7 @@ class EB_Score_minus_P(ConfigureMake):
             'OPARI2': ['--with-opari2=%s/bin'],
             'PAPI': ['--with-papi-header=%s/include', '--with-papi-lib=%%s/%s' % get_software_libdir('PAPI')],
             'PDT': ['--with-pdt=%s/bin'],
+            'Qt': ['--with-qt=%s'],
         }
         for (dep_name, dep_opts) in deps.items():
             dep_root = get_software_root(dep_name)


### PR DESCRIPTION
Depends on https://github.com/hpcugent/easybuild-framework/pull/1164 to be usable with toolchains that don't provide MPI.