### PR TITLE
minor fixes in EasyBuildMeta easyblock w.r.t. supporting bootstrapping using provided tarballs

### DIFF
--- a/easybuild/easyblocks/e/easybuildmeta.py
+++ b/easybuild/easyblocks/e/easybuildmeta.py
@@ -69,8 +69,8 @@ class EB_EasyBuildMeta(PythonPackage):
 
         try:
             subdirs = os.listdir(self.builddir)
-            for pkg in ['easyconfigs', 'easyblocks', 'framework']:
-                seldirs = [x for x in subdirs if x.startswith('easybuild-%s-' % pkg)]
+            for pkg in ['framework', 'easyblocks', 'easyconfigs']:
+                seldirs = [x for x in subdirs if x.startswith('easybuild-%s' % pkg)]
                 if not len(seldirs) == 1:
                     self.log.error("Failed to find EasyBuild %s package (subdirs: %s, seldirs: %s)" % (pkg, subdirs, seldirs))
 


### PR DESCRIPTION
required for bootstrapping with provided source tarballs, see https://github.com/hpcugent/easybuild-framework/pull/1184