### PR TITLE
Improved openifs block

### DIFF
--- a/easybuild/easyblocks/o/openifs.py
+++ b/easybuild/easyblocks/o/openifs.py
@@ -35,6 +35,7 @@ import easybuild.tools.toolchain as toolchain
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
+from distutils.version import LooseVersion
 
 
 class EB_OpenIFS(EasyBlock):
@@ -48,11 +49,11 @@ class EB_OpenIFS(EasyBlock):
 
         # configure build via OIFS_* environment variables
         env.setvar('OIFS_ARCH', 'x86_64')
-        env.setvar('OIFS_BUILD', 'opt')
+        env.setvar('OIFS_BUILD', 'noopt')
         if self.toolchain.comp_family() == toolchain.GCC:
             env.setvar('OIFS_COMP', 'gnu')
         elif self.toolchain.comp_family() == toolchain.INTELCOMP: 
-            env.setvar('OIFS_COMP', 'intel')
+            env.setvar('OIFS_COMP', 'intel_mkl')
         else:
             self.log.error("Unknown compiler used, don't know how to set $OIFS_COMP.")
 
@@ -60,7 +61,7 @@ class EB_OpenIFS(EasyBlock):
         env.setvar('OIFS_CC', os.getenv('CC'))
         env.setvar('OIFS_CFLAGS', os.getenv('CFLAGS'))
         env.setvar('OIFS_FC', os.getenv('F90'))
-        env.setvar('OIFS_FFLAGS', os.getenv('F90FLAGS'))
+        env.setvar('OIFS_FFLAGS', os.getenv('F90FLAGS') + " -convert big_endian")
 
         # set location of dependencies
         grib_api_root = get_software_root('grib_api')
@@ -80,13 +81,22 @@ class EB_OpenIFS(EasyBlock):
 
         # enable parallel build
         par = self.cfg['parallel']
-        cmd = "fcm make -v -j %s -f fcmcfg/oifs.cfg" % par
+        if LooseVersion(self.version) == LooseVersion('38r1v01'):
+            cmd = "fcm make -v -j %s -f fcmcfg/oifs.cfg" % par
+        elif LooseVersion(self.version) == LooseVersion('38r1v02'):
+            cmd = "fcm make -v -j %s -f cfg/oifs.cfg" % par
+        else:
+            cmd = "fcm make -v -j %s -f oifs.cfg" % par
+        
         run_cmd(cmd, log_all=True, simple=True, log_ok=True)
 
     def install_step(self):
         """Custom install procedure for OpenIFS: copy bin and include files."""
         try:
-            srcdir = os.path.join(self.cfg['start_dir'], 'make', os.getenv('OIFS_BUILD'), 'oifs')
+            if LooseVersion(self.version) <= LooseVersion('38r1v02'):
+                srcdir = os.path.join(self.cfg['start_dir'], 'make', os.getenv('OIFS_BUILD'), 'oifs')
+            else:
+                srcdir = os.path.join(self.cfg['start_dir'], 'make', os.getenv('OIFS_COMP') + '-' + os.getenv('OIFS_BUILD'), 'oifs')
             bindir = os.path.join(self.installdir, 'bin')
             os.makedirs(bindir)
             shutil.copy2(os.path.join(srcdir, 'bin', 'master.exe'), bindir)


### PR DESCRIPTION
Hi,

I am trying to make openifs easyblock working with newer version and I've realised that FCM is like EasyBuild and that they provide several configurations to compile the model.
omula@login:/tmp/oifs38r1v04/make/cfg$ ls -1
cce-nansC.cfg
cce-noopt.cfg
cce-opt.cfg
gnu-nansC.cfg
gnu-noopt.cfg
gnu-opt.cfg
ibm-nansC.cfg
ibm-noopt.cfg
ibm-opt.cfg
intel_mkl-nansC.cfg
intel_mkl-noopt.cfg
intel_mkl-opt.cfg
intel-nansC.cfg
intel-noopt.cfg
intel-opt.cfg
lapack.cfg
oifs-depend.cfg
oifs_xlf_wrapper
pgi-nansC.cfg
pgi-noopt.cfg
pgi-opt.cfg

diff -rupN intel_mkl-opt.cfg intel_mkl-noopt.cfg
--- intel_mkl-opt.cfg 2014-10-13 16:25:37.000000000 +0200
+++ intel_mkl-noopt.cfg 2014-10-13 16:25:37.000000000 +0200
@@ -1,5 +1,5 @@
FCM compiler & build specific configuration file for OpenIFS

-# intel_mkl compiler, opt build
+# intel_mkl compiler, noopt build
Glenn Carver ECMWF 2012-2014

@@ -30,15 +30,15 @@ $OIFS_SRC_EXCL{?} =
Fortran

$OIFS_FC{?} = mpiifort
-$OIFS_FFLAGS{?} = -g -m64 -openmp -O1 -xHost -fp-model precise -convert big_endian -traceback
+$OIFS_FFLAGS{?} = -g -m64 -O0 -fp-model precise -convert big_endian -traceback
$OIFS_FFIXED{?} = -r8
$OIFS_FCDEFS{?} = BLAS LITTLE LINUX INTEGER_IS_INT
-$OIFS_LFLAGS{?} = -openmp
+$OIFS_LFLAGS{?} =
C compiler

$OIFS_CC{?} = mpiicc
-$OIFS_CFLAGS{?} = -g -O
+$OIFS_CFLAGS{?} = -g -O0
$OIFS_CCDEFS{?} = BLAS LITTLE LINUX INTEGER_IS_INT _ABI64
Architecture/compiler specific FCM (if any)

Further information on compiling OpenIFS can be found in https://software.ecmwf.int/wiki/display/OIFS/How+to+customize+compiling+OpenIFS

Which would be the best way to improve the easyblock? You can have a look to my current attempt now in https://github.com/omula/easybuild-easyblocks/tree/develop-openifs

In order to make it work I had to add the -convert big_endian to the flags. Would you leave it as it is right now?

Cheers,
Oriol