### PR TITLE
fix easyblock for EasyBuild to support upgrade path to EasyBuild v2.0

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -5,6 +5,11 @@ These release notes can also be consulted at http://easybuild.readthedocs.org/en
 
 The latest version of easybuild-easyblocks provides 141 software-specific easyblocks and 20 generic easyblocks.
 
+v1.16.2 (March 6th 2015)
+------------------------
+
+- make EB_EasyBuildMeta easyblock aware of vsc-base to make upgrading to EasyBuild v2.0.0 possible (#573)
+
 v1.16.1 (December 19th 2014)
 ----------------------------
 

--- a/easybuild/easyblocks/__init__.py
+++ b/easybuild/easyblocks/__init__.py
@@ -33,7 +33,7 @@ from pkgutil import extend_path
 
 # note: release candidates should be versioned as a pre-release, e.g. "1.1rc1"
 # 1.1-rc1 would indicate a post-release, i.e., and update of 1.1, so beware
-VERSION = LooseVersion("1.16.1")
+VERSION = LooseVersion("1.16.2")
 UNKNOWN = "UNKNOWN"
 
 

--- a/easybuild/easyblocks/e/easybuildmeta.py
+++ b/easybuild/easyblocks/e/easybuildmeta.py
@@ -69,14 +69,16 @@ class EB_EasyBuildMeta(PythonPackage):
 
         try:
             subdirs = os.listdir(self.builddir)
-            for pkg in ['easyconfigs', 'easyblocks', 'framework']:
-                seldirs = [x for x in subdirs if x.startswith('easybuild-%s-' % pkg)]
+            for pkg in ['vsc-base', 'easybuild-framework', 'easybuild-easyblocks', 'easybuild-easyconfigs']:
+                seldirs = [x for x in subdirs if x.startswith(pkg)]
                 if not len(seldirs) == 1:
-                    self.log.error("Failed to find EasyBuild %s package (subdirs: %s, seldirs: %s)" % (pkg, subdirs, seldirs))
-
-                self.log.debug("Installing EasyBuild package %s" % pkg)
-                os.chdir(os.path.join(self.builddir, seldirs[0]))
-                super(EB_EasyBuildMeta, self).install_step()
+                    if pkg != 'vsc-base':
+                        tup = (pkg, subdirs, seldirs)
+                        self.log.error("Failed to find EasyBuild %s package (subdirs: %s, seldirs: %s)" % tup)
+                else:
+                    self.log.debug("Installing EasyBuild package %s" % pkg)
+                    os.chdir(os.path.join(self.builddir, seldirs[0]))
+                    super(EB_EasyBuildMeta, self).install_step()
 
         except OSError, err:
             self.log.error("Failed to install EasyBuild packages: %s" % err)


### PR DESCRIPTION
The easyblock used for installing EasyBuild included in EasyBuild v1.16.1 is unaware of the extra `vsc-base` component in the upcoming EasyBuild v2.0.0. This PR fixes that issue, supporting an intermediate release EasyBuild v1.16.2 which does support upgrading to EasyBuild v2.0.0.