### PR TITLE
fix definition of $MKLROOT, should be set to 'mkl' subdir of install dir

### DIFF
--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -143,7 +143,7 @@ class EB_imkl(IntelBase):
             txt += self.module_generator.prepend_paths('NLSPATH', '$root/idb/32/locale/%l_%t/%N')
         else:
             txt += self.module_generator.prepend_paths('NLSPATH', '$root/idb/intel64/locale/%l_%t/%N')
-        txt += self.module_generator.set_environment('MKLROOT', '$root/mkl')
+        txt += self.module_generator.set_environment('MKLROOT', os.path.join(self.installdir, 'mkl'))
         return txt
 
     def post_install_step(self):

--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -143,7 +143,7 @@ class EB_imkl(IntelBase):
             txt += self.module_generator.prepend_paths('NLSPATH', '$root/idb/32/locale/%l_%t/%N')
         else:
             txt += self.module_generator.prepend_paths('NLSPATH', '$root/idb/intel64/locale/%l_%t/%N')
-        txt += self.module_generator.set_environment('MKLROOT', '$root')
+        txt += self.module_generator.set_environment('MKLROOT', '$root/mkl')
         return txt
 
     def post_install_step(self):


### PR DESCRIPTION
bug mentioned by @klust

in practice, this doesn't make too much of a difference for use of `eb` itself (w.r.t. use of `$MKLROOT` in easyblocks/easyconfigs), but the path is incorrect w.r.t. MKL Link Advisor