### PR TITLE
Create buildenv.py

### DIFF
--- a/easybuild/easyblocks/b/buildenv.py
+++ b/easybuild/easyblocks/b/buildenv.py
@@ -1,0 +1,44 @@
+##
+# Copyright 2009-2015 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://vscentrum.be/nl/en),
+# the Hercules foundation (http://www.herculesstichting.be/in_English)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# http://github.com/hpcugent/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for creating a module that loads the build 
+environment flags for the current toolchain 
+
+@author: Alan O'Cais (Juelich Supercomputing Centre)
+"""
+
+from easybuild.easyblocks.generic.bundle import Bundle
+
+class BuildEnv(Bundle):
+    """
+    Build environment of toolchain: only generate module files
+    """
+    def make_module_extra(self):
+        """Add all the build environment variables."""
+        txt = super(Bundle, self).make_module_extra()
+        for key, val in self.toolchain.vars.items():
+            txt += self.module_generator.set_environment(key, val)
+        self.log.debug("make_module_extra added this: %s" % txt)
+        return txt


### PR DESCRIPTION
This easyblock will dump out a set of environment variables that are useful for people who are building their own software outside of easybuild. It will allow them to use generic envvars in their build processes so they can easily switch between toolchains