### PR TITLE
Add libmpichf90 to the libmpi variables

### DIFF
--- a/easybuild/easyblocks/n/nwchem.py
+++ b/easybuild/easyblocks/n/nwchem.py
@@ -184,7 +184,7 @@ class EB_NWChem(ConfigureMake):
             else:
                 libmpi = "-lmpigf -lmpigi -lmpi_ilp64 -lmpi"
         elif mpi_family in [toolchain.MPICH, toolchain.MPICH2]:
-            libmpi = "-lmpich -lopa -lmpl -lrt -lpthread"
+            libmpi = "-lmpichf90 -lmpich -lopa -lmpl -lrt -lpthread"
         else:
             self.log.error("Don't know how to set LIBMPI for %s" % mpi_family)
         env.setvar('LIBMPI', libmpi)


### PR DESCRIPTION
For NWChem to build with the latest version of psmpi (which includes proper MPI 3.0 support) the additional lib is required to build. We've chosen libmpichf90 (which is just a soft link to libmpifort, that is the library that appears in ```mpifort -show```) to ensure backwards compatibility