### PR TITLE
replace 'log.error' with 'raise EasyBuildError'

### DIFF
--- a/easybuild/easyblocks/a/abaqus.py
+++ b/easybuild/easyblocks/a/abaqus.py
@@ -35,6 +35,7 @@ import os
 
 from easybuild.easyblocks.generic.binary import Binary
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
 from distutils.version import LooseVersion
 
@@ -72,7 +73,7 @@ class EB_ABAQUS(Binary):
             f.write(txt)
             f.close()
         except IOError, err:
-            self.log.error("Failed to create install properties file used for replaying installation: %s" % err)
+            raise EasyBuildError("Failed to create install properties file used for replaying installation: %s", err)
 
     def install_step(self):
         """Install ABAQUS using 'setup'."""

--- a/easybuild/easyblocks/a/aladin.py
+++ b/easybuild/easyblocks/a/aladin.py
@@ -38,6 +38,7 @@ import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.ordereddict import OrderedDict
 from easybuild.tools.run import run_cmd, run_cmd_qa
@@ -86,7 +87,7 @@ class EB_ALADIN(EasyBlock):
         elif self.toolchain.comp_family() == toolchain.INTELCOMP:
             my_gnu = 'i'  # icc/ifort
         else:
-            self.log.error("Don't know how to set 'my_gnu' variable in auxlibs build script.")
+            raise EasyBuildError("Don't know how to set 'my_gnu' variable in auxlibs build script.")
         self.log.info("my_gnu set to '%s'" % my_gnu)
 
         tmp_installroot = tempfile.mkdtemp(prefix='aladin_auxlibs_')
@@ -116,7 +117,7 @@ class EB_ALADIN(EasyBlock):
             os.chdir(cwd)
 
         except OSError, err:
-            self.log.error("Failed to build ALADIN: %s" % err)
+            raise EasyBuildError("Failed to build ALADIN: %s", err)
 
         # build gmkpack, update PATH and set GMKROOT
         # we build gmkpack here because a config file is generated in the gmkpack isntall path
@@ -139,7 +140,7 @@ class EB_ALADIN(EasyBlock):
             env.setvar('GMKROOT', os.path.join(self.builddir, gmkpack_dir))
 
         except OSError, err:
-            self.log.error("Failed to build gmkpack: %s" % err)
+            raise EasyBuildError("Failed to build gmkpack: %s", err)
 
         # generate gmkpack configuration file
         self.conf_file = 'ALADIN_%s' % self.version
@@ -155,7 +156,7 @@ class EB_ALADIN(EasyBlock):
                 os.makedirs(archdir)
 
         except OSError, err:
-            self.log.error("Failed to remove existing file %s: %s" % (self.conf_filepath, err))
+            raise EasyBuildError("Failed to remove existing file %s: %s", self.conf_filepath, err)
 
         mpich = 'n'
         known_mpi_libs = [toolchain.MPICH, toolchain.MPICH2, toolchain.INTELMPI]
@@ -172,7 +173,7 @@ class EB_ALADIN(EasyBlock):
         elif comp_fam == toolchain.INTELCOMP:
             gribdir = 'INTEL'
         else:
-            self.log.error("Don't know which grib lib dir to use for compiler %s" % comp_fam)
+            raise EasyBuildError("Don't know which grib lib dir to use for compiler %s", comp_fam)
 
         aux_lib_gribex = os.path.join(tmp_installroot, gribdir, 'lib', 'libgribex.a')
         aux_lib_ibm = os.path.join(tmp_installroot, gribdir, 'lib', 'libibmdummy.a')
@@ -267,7 +268,7 @@ class EB_ALADIN(EasyBlock):
             os.mkdir(os.getenv('ROOTPACK'))
             os.mkdir(os.getenv('HOMEPACK'))
         except OSError, err:
-            self.log.error("Failed to create rootpack dir in %s: %s" % err)
+            raise EasyBuildError("Failed to create rootpack dir in %s: %s", err)
 
         # create rootpack
         [v1, v2] = self.version.split('_')
@@ -278,7 +279,7 @@ class EB_ALADIN(EasyBlock):
         if res:
             self.rootpack_dir = os.path.join('rootpack', res.group(1))
         else:
-            self.log.error("Failed to determine rootpack dir.")
+            raise EasyBuildError("Failed to determine rootpack dir.")
 
         # copy ALADIN sources to right directory
         try:
@@ -289,7 +290,7 @@ class EB_ALADIN(EasyBlock):
                 shutil.copytree(os.path.join(self.builddir, srcdir), os.path.join(target, srcdir))
                 self.log.info("Copied %s" % srcdir)
         except OSError, err:
-            self.log.error("Failed to copy ALADIN sources: %s" % err)
+            raise EasyBuildError("Failed to copy ALADIN sources: %s", err)
 
         if self.cfg['parallel']:
             env.setvar('GMK_THREADS', str(self.cfg['parallel']))

--- a/easybuild/easyblocks/a/allinea.py
+++ b/easybuild/easyblocks/a/allinea.py
@@ -34,6 +34,7 @@ from os.path import expanduser
 from easybuild.easyblocks.generic.binary import Binary
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 
 
 class EB_Allinea(Binary):
@@ -56,7 +57,7 @@ class EB_Allinea(Binary):
         """No configuration for Allinea."""
         # ensure a license file is specified
         if self.cfg['license_file'] is None:
-            self.log.error("No license file specified.")
+            raise EasyBuildError("No license file specified.")
 
     def build_step(self):
         """No build step for Allinea."""
@@ -75,7 +76,7 @@ class EB_Allinea(Binary):
         try:
             shutil.copy2(self.cfg['license_file'], lic_path)
         except OSError, err:
-            self.log.error("Failed to copy license file to %s: %s" % (lic_path, err))
+            raise EasyBuildError("Failed to copy license file to %s: %s", lic_path, err)
 
         # copy templates
         templ_path = os.path.join(self.installdir, 'templates')
@@ -83,7 +84,7 @@ class EB_Allinea(Binary):
             try:
                 shutil.copy2(templ, templ_path)
             except OSError, err:
-                self.log.error("Failed to copy template %s to %s: %s" % (templ, templ_path, err))
+                raise EasyBuildError("Failed to copy template %s to %s: %s", templ, templ_path, err)
 
     def sanity_check_step(self):
         """Custom sanity check for Allinea."""

--- a/easybuild/easyblocks/a/ant.py
+++ b/easybuild/easyblocks/a/ant.py
@@ -32,6 +32,7 @@ import os
 import shutil
 
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
 
@@ -52,7 +53,7 @@ class EB_ant(EasyBlock):
 
         junit_root = get_software_root('JUnit')
         if not junit_root:
-            self.log.error("JUnit module not loaded!")
+            raise EasyBuildError("JUnit module not loaded!")
 
         junit_ver = get_software_version('JUnit')
 
@@ -61,7 +62,7 @@ class EB_ant(EasyBlock):
             shutil.copy(os.path.join(junit_root, 'junit-%s.jar' % junit_ver),
                         os.path.join(os.getcwd(), "lib", "optional"))
         except OSError, err:
-            self.log.error("Failed to copy JUnit jar: %s" % err)
+            raise EasyBuildError("Failed to copy JUnit jar: %s", err)
 
         cmd = "sh build.sh -Ddist.dir=%s dist" % self.installdir
 

--- a/easybuild/easyblocks/a/armadillo.py
+++ b/easybuild/easyblocks/a/armadillo.py
@@ -30,6 +30,7 @@ EasyBuild support for Armadillo, implemented as an easyblock
 import os
 
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 
 
@@ -41,7 +42,7 @@ class EB_Armadillo(CMakeMake):
 
         boost = get_software_root('Boost')
         if not boost:
-            self.log.error("Dependency module Boost not loaded?")
+            raise EasyBuildError("Dependency module Boost not loaded?")
 
         self.cfg.update('configopts', "-DBoost_DIR=%s" % boost)
         self.cfg.update('configopts', "-DBOOST_INCLUDEDIR=%s/include" % boost)

--- a/easybuild/easyblocks/b/bamtools.py
+++ b/easybuild/easyblocks/b/bamtools.py
@@ -32,6 +32,7 @@ import os
 
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.easyblocks.generic.makecp import MakeCp
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import mkdir
 from easybuild.tools.systemtools import get_shared_lib_ext
 
@@ -42,12 +43,12 @@ class EB_BamTools(MakeCp, CMakeMake):
     def configure_step(self):
         """Configure BamTools build."""
         # BamTools requires an out of source build.
+        builddir = os.path.join(self.cfg['start_dir'], 'build')
         try:
-            builddir = os.path.join(self.cfg['start_dir'], 'build')
             mkdir(builddir)
             os.chdir(builddir)
         except OSError, err:
-            self.log.error("")
+            raise EasyBuildError("Failed to move to %s: %s", builddir, err)
 
         CMakeMake.configure_step(self, srcdir='..')
 

--- a/easybuild/easyblocks/b/bioconductor.py
+++ b/easybuild/easyblocks/b/bioconductor.py
@@ -32,6 +32,7 @@ EasyBuild support for building and installing the Bioconductor R library, implem
 @author: Toon Willems (Ghent University)
 """
 from easybuild.easyblocks.generic.rpackage import RPackage
+from easybuild.tools.build_log import EasyBuildError
 
 
 class EB_Bioconductor(RPackage):
@@ -41,17 +42,17 @@ class EB_Bioconductor(RPackage):
     """
     def make_cmdline_cmd(self):
         """Create a command line to install an R library."""
-        self.log.error("Don't know how to install a specific version of a bioconductor package.")
+        raise EasyBuildError("Don't know how to install a specific version of a Bioconductor package.")
 
     def make_r_cmd(self):
         """Create a command to run in R to install an R library."""
         name = self.ext['name']
-        self.log.debug("Installing bioconductor package %s." % name)
+        self.log.debug("Installing Bioconductor package %s." % name)
 
         r_cmd = '\n'.join([
-                           'source("http://bioconductor.org/biocLite.R")',
-                           'biocLite("%s")' % name,
-                          ])
+            'source("http://bioconductor.org/biocLite.R")',
+            'biocLite("%s")' % name,
+        ])
         cmd = "R -q --no-save"
 
         return cmd, r_cmd

--- a/easybuild/easyblocks/b/blacs.py
+++ b/easybuild/easyblocks/b/blacs.py
@@ -38,6 +38,7 @@ import os
 import shutil
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
 
 
@@ -52,7 +53,7 @@ def det_interface(log, path):
     if res:
         return res.group(1)
     else:
-        log.error("Failed to determine interface, output for xintface: %s" % out)
+        raise EasyBuildError("Failed to determine interface, output for xintface: %s", out)
 
 
 class EB_BLACS(ConfigureMake):
@@ -69,15 +70,15 @@ class EB_BLACS(ConfigureMake):
         dest = os.path.join(self.cfg['start_dir'], 'Bmake.inc')
 
         if not os.path.isfile(src):
-            self.log.error("Can't find source file %s" % src)
+            raise EasyBuildError("Can't find source file %s", src)
 
         if os.path.exists(dest):
-            self.log.error("Destination file %s exists" % dest)
+            raise EasyBuildError("Destination file %s exists", dest)
 
         try:
             shutil.copy(src, dest)
         except OSError, err:
-            self.log.error("Copying %s to % failed: %s" % (src, dest, err))
+            raise EasyBuildError("Copying %s to %s failed: %s", src, dest, err)
 
     def build_step(self):
         """Build BLACS using build_step, after figuring out the make options based on the heuristic tools available."""
@@ -147,7 +148,7 @@ class EB_BLACS(ConfigureMake):
 
             os.chdir(cwd)
         except OSError, err:
-            self.log.error("Failed to determine interface and transcomm settings: %s" % err)
+            raise EasyBuildError("Failed to determine interface and transcomm settings: %s", err)
 
         opts.update({
                      'comm': comm,
@@ -191,7 +192,7 @@ class EB_BLACS(ConfigureMake):
                         self.log.debug("Symlinked %s/%s to %s" % (dest, lib, symlink_name))
 
             except OSError, err:
-                self.log.error("Copying %s/*.%s to installation dir %s failed: %s"%(src, ext, dest, err))
+                raise EasyBuildError("Copying %s/*.%s to installation dir %s failed: %s", src, ext, dest, err)
 
         # utilities
         src = os.path.join(self.cfg['start_dir'], 'INSTALL', 'EXE', 'xintface')
@@ -205,7 +206,7 @@ class EB_BLACS(ConfigureMake):
             self.log.debug("Copied %s to %s" % (src, dest))
 
         except OSError, err:
-            self.log.error("Copying %s to installation dir %s failed: %s" % (src, dest, err))
+            raise EasyBuildError("Copying %s to installation dir %s failed: %s", src, dest, err)
 
     def sanity_check_step(self):
         """Custom sanity check for BLACS."""

--- a/easybuild/easyblocks/b/bowtie.py
+++ b/easybuild/easyblocks/b/bowtie.py
@@ -35,6 +35,7 @@ import os
 import shutil
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 
 
 class EB_Bowtie(ConfigureMake):
@@ -61,7 +62,7 @@ class EB_Bowtie(ConfigureMake):
                 srcfile = os.path.join(srcdir, filename)
                 shutil.copy2(srcfile, destdir)
         except (IOError, OSError), err:
-            self.log.error("Copying %s to installation dir %s failed: %s" % (srcfile, destdir, err))
+            raise EasyBuildError("Copying %s to installation dir %s failed: %s", srcfile, destdir, err)
 
     def sanity_check_step(self):
         """Custom sanity check for Bowtie."""

--- a/easybuild/easyblocks/b/bowtie2.py
+++ b/easybuild/easyblocks/b/bowtie2.py
@@ -21,6 +21,7 @@ import os
 import shutil
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 
 
 class EB_Bowtie2(ConfigureMake):
@@ -49,7 +50,7 @@ class EB_Bowtie2(ConfigureMake):
                 srcfile = os.path.join(srcdir, filename)
                 shutil.copy2(srcfile, destdir)
         except OSError, err:
-            self.log.error("Copying %s to installation dir %s failed: %s" % (srcfile, destdir, err))
+            raise EasyBuildError("Copying %s to installation dir %s failed: %s", srcfile, destdir, err)
 
     def sanity_check_step(self):
         """Custom sanity check for Bowtie2."""

--- a/easybuild/easyblocks/b/bwa.py
+++ b/easybuild/easyblocks/b/bwa.py
@@ -24,6 +24,7 @@ import shutil
 from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 
 
 class EB_BWA(ConfigureMake):
@@ -59,7 +60,7 @@ class EB_BWA(ConfigureMake):
                 srcfile = os.path.join(srcdir, filename)
                 shutil.copy2(srcfile, destdir)
         except OSError, err:
-            self.log.error("Copying %s to installation dir %s failed: %s" % (srcfile, destdir, err))
+            raise EasyBuildError("Copying %s to installation dir %s failed: %s", srcfile, destdir, err)
 
     def sanity_check_step(self):
         """Custom sanity check for BWA."""

--- a/easybuild/easyblocks/c/cblas.py
+++ b/easybuild/easyblocks/c/cblas.py
@@ -33,6 +33,7 @@ import os
 import shutil
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 
 
 class EB_CBLAS(ConfigureMake):
@@ -48,7 +49,7 @@ class EB_CBLAS(ConfigureMake):
         try:
             shutil.copy2('Makefile.LINUX', 'Makefile.in')
         except OSError, err:
-            self.log.error("Failed to copy makefile: %s" % err)
+            raise EasyBuildError("Failed to copy makefile: %s", err)
 
         if not self.cfg['buildopts']:
             self.cfg.update('buildopts', 'all')
@@ -78,7 +79,7 @@ class EB_CBLAS(ConfigureMake):
                 for solib in glob.glob(os.path.join(srcdir, 'libcblas.so*')):
                     shutil.copy2(solib, targetdir)
         except OSError, err:
-            self.log.error("Failed to install CBLAS (srcdir: %s, targetdir: %s): %s" % (srcdir, targetdir, err))
+            raise EasyBuildError("Failed to install CBLAS (srcdir: %s, targetdir: %s): %s", srcdir, targetdir, err)
 
     def sanity_check_step(self):
         """

--- a/easybuild/easyblocks/c/cgal.py
+++ b/easybuild/easyblocks/c/cgal.py
@@ -31,6 +31,7 @@ EasyBuild support for CGAL, implemented as an easyblock
 import os
 
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 
 
@@ -43,7 +44,7 @@ class EB_CGAL(CMakeMake):
         deps = ["Boost", "GMP", "MPFR"]
         for dep in deps:
             if not get_software_root(dep):
-                self.log.error("Dependency module %s not loaded?" % dep)
+                raise EasyBuildError("Dependency module %s not loaded?", dep)
 
         for lib in ["GMP", "MPFR"]:
             os.environ['%s_INC_DIR' % lib] = "%s%s" % (get_software_root(lib), "/include/")

--- a/easybuild/easyblocks/c/charmm.py
+++ b/easybuild/easyblocks/c/charmm.py
@@ -33,6 +33,7 @@ import shutil
 
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
 import easybuild.tools.toolchain as toolchain
@@ -69,7 +70,7 @@ class EB_CHARMM(EasyBlock):
     def build_step(self, verbose=False):
         """Start the actual build"""
         if self.cfg['system_size'] not in KNOWN_SYSTEM_SIZES:
-            self.log.error("Unknown system size '%s' specified, known: %s" % (self.cfg['system_size'], KNOWN_SYSTEM_SIZES))
+            raise EasyBuildError("Unknown system size '%s' specified, known: %s", self.cfg['system_size'], KNOWN_SYSTEM_SIZES)
 
         self.log.info("Building for size: %s" % self.cfg['system_size'])
         self.log.info("Build options from the easyconfig: %s" % self.cfg['build_options'])
@@ -134,7 +135,7 @@ class EB_CHARMM(EasyBlock):
         try:
             shutil.copytree(self.cfg['start_dir'], self.installdir)
         except OSError, err:
-            self.log.error("Failed to copy CHARMM dir to install dir: %s" % err)
+            raise EasyBuildError("Failed to copy CHARMM dir to install dir: %s", err)
 
     def make_module_req_guess(self):
         """Custom guesses for environment variable PATH for CHARMM."""

--- a/easybuild/easyblocks/c/chimera.py
+++ b/easybuild/easyblocks/c/chimera.py
@@ -9,6 +9,7 @@ EasyBuild support for installing Chimera, implemented as an easyblock
 import os
 
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
 
 
@@ -36,7 +37,7 @@ class EB_Chimera(EasyBlock):
         try:
             os.chdir(self.cfg['start_dir'])
         except OSError, err:
-            self.log.error("Failed to change to %s: %s" % (self.cfg['start_dir'], err))
+            raise EasyBuildError("Failed to change to %s: %s", self.cfg['start_dir'], err)
 
         cmd = "./chimera.bin -q -d %s" % self.installdir
 

--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -42,6 +42,7 @@ from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import mkdir
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
@@ -81,22 +82,22 @@ class EB_Clang(CMakeMake):
         unknown_targets = [target for target in self.cfg['build_targets'] if target not in CLANG_TARGETS]
 
         if unknown_targets:
-            self.log.error("Some of the chosen build targets (%s) are not in %s." % (", ".join(unknown_targets),
-                                                                                     ", ".join(CLANG_TARGETS)))
+            raise EasyBuildError("Some of the chosen build targets (%s) are not in %s.",
+                                 ', '.join(unknown_targets), ', '.join(CLANG_TARGETS))
 
         if LooseVersion(self.version) < LooseVersion('3.4') and "R600" in self.cfg['build_targets']:
-            self.log.error("Build target R600 not supported in < Clang-3.4")
+            raise EasyBuildError("Build target R600 not supported in < Clang-3.4")
 
         if LooseVersion(self.version) > LooseVersion('3.3') and "MBlaze" in self.cfg['build_targets']:
-            self.log.error("Build target MBlaze is not supported anymore in > Clang-3.3")
+            raise EasyBuildError("Build target MBlaze is not supported anymore in > Clang-3.3")
 
     def check_readiness_step(self):
         """Fail early on RHEL 5.x and derivatives because of known bug in libc."""
         super(EB_Clang, self).check_readiness_step()
         # RHEL 5.x have a buggy libc.  Building stage 2 will fail.
         if get_os_name() in ['redhat', 'RHEL', 'centos', 'SL'] and get_os_version().startswith('5.'):
-            self.log.error(("Can not build clang on %s v5.x: libc is buggy, building stage 2 will fail.  " +
-                            "See http://stackoverflow.com/questions/7276828/") % get_os_name())
+            raise EasyBuildError("Can not build Clang on %s v5.x: libc is buggy, building stage 2 will fail. "
+                                 "See http://stackoverflow.com/questions/7276828/", get_os_name())
 
     def extract_step(self):
         """
@@ -119,11 +120,11 @@ class EB_Clang(CMakeMake):
                 break
 
         if self.llvm_src_dir is None:
-            self.log.error("Could not determine LLVM source root (LLVM source was not unpacked?)")
+            raise EasyBuildError("Could not determine LLVM source root (LLVM source was not unpacked?)")
 
         compiler_rt_src_dirs = glob.glob('compiler-rt-*')
         if len(compiler_rt_src_dirs) != 1:
-            self.log.error("Failed to find exactly one compiler-rt source directory: %s" % compiler_rt_src_dirs)
+            raise EasyBuildError("Failed to find exactly one compiler-rt source directory: %s", compiler_rt_src_dirs)
         compiler_rt_src_dir = compiler_rt_src_dirs[0]
 
         src_dirs = {
@@ -133,14 +134,14 @@ class EB_Clang(CMakeMake):
         if self.cfg["usepolly"]:
             polly_src_dirs = glob.glob('polly-*')
             if len(polly_src_dirs) != 1:
-                self.log.error("Failed to find exactly one polly source directory: %s" % polly_src_dirs)
+                raise EasyBuildError("Failed to find exactly one polly source directory: %s", polly_src_dirs)
             polly_src_dir = polly_src_dirs[0]
             src_dirs[polly_src_dir] = os.path.join(self.llvm_src_dir, 'tools', 'polly')
 
         clang_src_dirs = glob.glob('clang-*') + glob.glob('cfe-*')
 
         if len(clang_src_dirs) != 1:
-            self.log.error("Failed to find exactly one clang source directory: %s" % clang_src_dirs)
+            raise EasyBuildError("Failed to find exactly one clang source directory: %s", clang_src_dirs)
         clang_src_dir = clang_src_dirs[0]
 
         src_dirs[clang_src_dir] = os.path.join(self.llvm_src_dir, 'tools', 'clang')
@@ -152,7 +153,7 @@ class EB_Clang(CMakeMake):
                     try:
                         shutil.move(old_path, new_path)
                     except IOError, err:
-                        self.log.error("Failed to move %s to %s: %s" % (old_path, new_path, err))
+                        raise EasyBuildError("Failed to move %s to %s: %s", old_path, new_path, err)
                     tmp['finalpath'] = new_path
                     break
 
@@ -219,7 +220,7 @@ class EB_Clang(CMakeMake):
                             if "add_subdirectory(lit_tests)" not in line:
                                 sys.stdout.write(line)
                     except (IOError, OSError), err:
-                        self.log.error("Failed to patch %s: %s" % (patchfile_fp, err))
+                        raise EasyBuildError("Failed to patch %s: %s", patchfile_fp, err)
                 else:
                     self.log.debug("Not patching non-existent %s in %s" % (patchfile, self.llvm_src_dir))
 
@@ -231,7 +232,7 @@ class EB_Clang(CMakeMake):
                     if "add_subdirectory(tests)" not in line:
                         sys.stdout.write(line)
             except IOError, err:
-                self.log.error("Failed to patch %s/%s: %s" % (self.llvm_src_dir, patchfile, err))
+                raise EasyBuildError("Failed to patch %s/%s: %s", self.llvm_src_dir, patchfile, err)
         else:
             # In Clang 3.6, the sanitizer tests are grouped together in one CMakeLists
             # We patch out adding the subdirectories with the sanitizer tests
@@ -244,7 +245,7 @@ class EB_Clang(CMakeMake):
                     if not patch_regex.search(line):
                         sys.stdout.write(line)
             except IOError, err:
-                self.log.error("Failed to patch %s: %s" % (patchfile_fp, err))
+                raise EasyBuildError("Failed to patch %s: %s", patchfile_fp, err)
 
     def build_with_prev_stage(self, prev_obj, next_obj):
         """Build Clang stage N using Clang stage N-1"""
@@ -327,7 +328,7 @@ class EB_Clang(CMakeMake):
                 os.makedirs(mandir)
                 shutil.copy2(os.path.join(tools_src_dir, 'scan-build', 'scan-build.1'), mandir)
             except OSError, err:
-                self.log.error("Failed to copy static analyzer dirs to install dir: %s" % err)
+                raise EasyBuildError("Failed to copy static analyzer dirs to install dir: %s", err)
 
     def sanity_check_step(self):
         """Custom sanity check for Clang."""

--- a/easybuild/easyblocks/c/cp2k.py
+++ b/easybuild/easyblocks/c/cp2k.py
@@ -567,8 +567,8 @@ class EB_CP2K(EasyBlock):
         makefiles = os.path.join(self.cfg['start_dir'], 'makefiles')
         try:
             os.chdir(makefiles)
-        except:
-            raise EasyBuildError("Can't change to makefiles dir %s: %s", makefiles)
+        except OSError, err:
+            raise EasyBuildError("Can't change to makefiles dir %s: %s", makefiles, err)
 
         # modify makefile for parallel build
         parallel = self.cfg['parallel']
@@ -604,7 +604,7 @@ class EB_CP2K(EasyBlock):
             try:
                 os.chdir(self.builddir)
             except OSError, err:
-                raise EasyBuildError("Failed to change to %s: %s", self.builddir)
+                raise EasyBuildError("Failed to change to %s: %s", self.builddir, err)
 
             # use regression test reference output if available
             # try and find an unpacked directory that starts with 'LAST-'

--- a/easybuild/easyblocks/c/cp2k.py
+++ b/easybuild/easyblocks/c/cp2k.py
@@ -44,6 +44,7 @@ from distutils.version import LooseVersion
 import easybuild.tools.toolchain as toolchain
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_avail_core_count
@@ -114,7 +115,8 @@ class EB_CP2K(EasyBlock):
 
         known_types = ['popt', 'psmp']
         if self.cfg['type'] not in known_types:
-            self.log.error("Unknown build type specified: '%s', known types are %s" % (self.cfg['type'], known_types))
+            raise EasyBuildError("Unknown build type specified: '%s', known types are %s",
+                                 self.cfg['type'], known_types)
 
         # correct start dir, if needed
         # recent CP2K versions have a 'cp2k' dir in the unpacked 'cp2k' dir
@@ -166,7 +168,7 @@ class EB_CP2K(EasyBlock):
         elif comp_fam == toolchain.GCC:
             options = self.configure_GCC_based()
         else:
-            self.log.error("Don't know how to tweak configuration for compiler used.")
+            raise EasyBuildError("Don't know how to tweak configuration for compiler used.")
 
         # BLAS related
         if get_software_root('IMKL'):
@@ -200,7 +202,7 @@ class EB_CP2K(EasyBlock):
             f.close()
             self.log.info("Content of makefile (%s):\n%s" % (archfile, txt))
         except IOError, err:
-            self.log.error("Writing makefile %s failed: %s" % (archfile, err))
+            raise EasyBuildError("Writing makefile %s failed: %s", archfile, err)
 
     def prepmodinc(self):
         """Prepare list of module files"""
@@ -218,7 +220,7 @@ class EB_CP2K(EasyBlock):
             try:
                 os.mkdir(modincpath)
             except OSError, err:
-                self.log.error("Failed to create directory for module include files: %s" % err)
+                raise EasyBuildError("Failed to create directory for module include files: %s", err)
 
             # get list of modinc source files
             modincdir = os.path.join(imkl, self.cfg["modincprefix"], 'include')
@@ -230,12 +232,12 @@ class EB_CP2K(EasyBlock):
                 modfiles = glob.glob(os.path.join(modincdir, '*.f90'))
 
             else:
-                self.log.error("prepmodinc: Please specify either a boolean value "
-                               "or a list of files in modinc (found: %s)." % self.cfg["modinc"])
+                raise EasyBuildError("prepmodinc: Please specify either a boolean value or a list of files in modinc "
+                                     "(found: %s).", self.cfg["modinc"])
 
             f77 = os.getenv('F77')
             if not f77:
-                self.log.error("F77 environment variable not set, can't continue.")
+                raise EasyBuildError("F77 environment variable not set, can't continue.")
 
             # create modinc files
             for f in modfiles:
@@ -244,13 +246,13 @@ class EB_CP2K(EasyBlock):
                 elif f77 in ['gfortran', 'mpif77']:
                     cmd = "%s -J%s -c %s" % (f77, modincpath, f)
                 else:
-                    self.log.error("prepmodinc: Unknown value specified for F77 (%s)" % f77)
+                    raise EasyBuildError("prepmodinc: Unknown value specified for F77 (%s)", f77)
 
                 run_cmd(cmd, log_all=True, simple=True)
 
             return modincpath
         else:
-            self.log.error("Don't know how to prepare modinc, IMKL not found")
+            raise EasyBuildError("Don't know how to prepare modinc, IMKL not found")
 
     def configure_common(self):
         """Common configuration for all toolchains"""
@@ -291,7 +293,7 @@ class EB_CP2K(EasyBlock):
                     self.log.debug("MPI-2 supporting MPI library %s not loaded.")
             
         if not mpi2:
-            self.log.error("CP2K needs MPI-2, no known MPI-2 supporting library loaded?")
+            raise EasyBuildError("CP2K needs MPI-2, no known MPI-2 supporting library loaded?")
 
         options = {
             'CC': os.getenv('MPICC'),
@@ -341,12 +343,12 @@ class EB_CP2K(EasyBlock):
                         libinttools_path = path
                         os.chdir(libinttools_path)
                 if not libinttools_path:
-                    self.log.error("No libinttools dir found")
+                    raise EasyBuildError("No libinttools dir found")
 
                 # build libint wrapper
                 cmd = "%s -c libint_cpp_wrapper.cpp -I%s/include" % (libintcompiler, libint)
                 if not run_cmd(cmd, log_all=True, simple=True):
-                    self.log.error("Building the libint wrapper failed")
+                    raise EasyBuildError("Building the libint wrapper failed")
                 libint_wrapper = '%s/libint_cpp_wrapper.o' % libinttools_path
 
             # determine LibInt libraries based on major version number
@@ -356,7 +358,7 @@ class EB_CP2K(EasyBlock):
             elif libint_maj_ver == '2':
                 libint_libs = "$(LIBINTLIB)/libint2.a"
             else:
-                self.log.error("Don't know how to handle libint version %s" % libint_maj_ver)
+                raise EasyBuildError("Don't know how to handle libint version %s", libint_maj_ver)
             self.log.info("Using LibInt version %s" % (libint_maj_ver))
 
             options['LIBINTLIB'] = '%s/lib' % libint
@@ -371,7 +373,7 @@ class EB_CP2K(EasyBlock):
         if libxc:
             cur_libxc_version = get_software_version('libxc')
             if LooseVersion(cur_libxc_version) < LooseVersion(LIBXC_MIN_VERSION):
-                self.log.error("CP2K only works with libxc v%s (or later)" % LIBXC_MIN_VERSION)
+                raise EasyBuildError("CP2K only works with libxc v%s (or later)", LIBXC_MIN_VERSION)
 
             options['DFLAGS'] += ' -D__LIBXC2'
             if LooseVersion(cur_libxc_version) >= LooseVersion('2.2'):
@@ -432,17 +434,17 @@ class EB_CP2K(EasyBlock):
                 self.make_instructions += "qs_vxc_atom.o: qs_vxc_atom.F\n\t$(FC) -c $(FCFLAGS2) $<\n"
 
             else:
-                self.log.error(failmsg % ("v12", "v2011.8"))
+                raise EasyBuildError(failmsg, "v12", "v2011.8")
 
         elif ifortver >= LooseVersion("11"):
             if LooseVersion(get_software_version('ifort')) >= LooseVersion("11.1.072"):
                 self.make_instructions += "qs_vxc_atom.o: qs_vxc_atom.F\n\t$(FC) -c $(FCFLAGS2) $<\n"
 
             else:
-                self.log.error(failmsg % ("v11", "v11.1.072"))
+                raise EasyBuildError(failmsg, "v11", "v11.1.072")
 
         else:
-            self.log.error("Intel compilers version %s not supported yet." % ifortver)
+            raise EasyBuildError("Intel compilers version %s not supported yet.", ifortver)
 
         return options
 
@@ -566,7 +568,7 @@ class EB_CP2K(EasyBlock):
         try:
             os.chdir(makefiles)
         except:
-            self.log.error("Can't change to makefiles dir %s: %s" % (makefiles))
+            raise EasyBuildError("Can't change to makefiles dir %s: %s", makefiles)
 
         # modify makefile for parallel build
         parallel = self.cfg['parallel']
@@ -577,7 +579,7 @@ class EB_CP2K(EasyBlock):
                     line = re.sub(r"^PMAKE\s*=.*$", "PMAKE\t= $(SMAKE) -j %s" % parallel, line)
                     sys.stdout.write(line)
             except IOError, err:
-                self.log.error("Can't modify/write Makefile in %s: %s" % (makefiles, err))
+                raise EasyBuildError("Can't modify/write Makefile in %s: %s", makefiles, err)
 
         # update make options with MAKE
         self.cfg.update('buildopts', 'MAKE="make -j %s" all' % self.cfg['parallel'])
@@ -602,7 +604,7 @@ class EB_CP2K(EasyBlock):
             try:
                 os.chdir(self.builddir)
             except OSError, err:
-                self.log.error("Failed to change to %s: %s" % self.builddir)
+                raise EasyBuildError("Failed to change to %s: %s", self.builddir)
 
             # use regression test reference output if available
             # try and find an unpacked directory that starts with 'LAST-'
@@ -629,14 +631,14 @@ class EB_CP2K(EasyBlock):
                         line = re.sub(r"^(dir_last\s*=\${dir_base})/.*$", r"\1/%s" % regtest_refdir, line)
                         sys.stdout.write(line)
                 except IOError, err:
-                    self.log.error("Failed to modify '%s': %s" % (regtest_script, err))
+                    raise EasyBuildError("Failed to modify '%s': %s", regtest_script, err)
 
             else:
                 self.log.info("No reference output found for regression test, just continuing without it...")
 
             test_core_cnt = min(self.cfg.get('parallel', sys.maxint), 2)
             if get_avail_core_count() < test_core_cnt:
-                self.log.error("Cannot run MPI tests as not enough cores (< %s) are available" % test_core_cnt)
+                raise EasyBuildError("Cannot run MPI tests as not enough cores (< %s) are available", test_core_cnt)
             else:
                 self.log.info("Using %s cores for the MPI tests" % test_core_cnt)
 
@@ -666,7 +668,7 @@ class EB_CP2K(EasyBlock):
                 f.write(cfg_txt)
                 f.close()
             except IOError, err:
-                self.log.error("Failed to create config file %s: %s" % (cfg_fn, err))
+                raise EasyBuildError("Failed to create config file %s: %s", cfg_fn, err)
 
             self.log.debug("Contents of %s: %s" % (cfg_fn, cfg_txt))
 
@@ -676,7 +678,7 @@ class EB_CP2K(EasyBlock):
             if ec == 0:
                 self.log.info("Regression test output:\n%s" % regtest_output)
             else:
-                self.log.error("Regression test failed (non-zero exit code): %s" % regtest_output)
+                raise EasyBuildError("Regression test failed (non-zero exit code): %s", regtest_output)
 
             # pattern to search for regression test summary
             re_pattern = "number\s+of\s+%s\s+tests\s+(?P<cnt>[0-9]+)"
@@ -688,8 +690,7 @@ class EB_CP2K(EasyBlock):
             if res:
                 tot_cnt = int(res.group('cnt'))
             else:
-                self.log.error("Finding total number of tests in regression test summary failed")
-            msg = "Regression test reported %%s / %s %%s tests" % tot_cnt
+                raise EasyBuildError("Finding total number of tests in regression test summary failed")
 
             # function to report on regtest results
             def test_report(test_result):
@@ -703,24 +704,26 @@ class EB_CP2K(EasyBlock):
                 cnt = None
                 res = regexp.search(regtest_output)
                 if not res:
-                    self.log.error("Finding number of %s tests in regression test summary failed" % test_result.lower())
+                    raise EasyBuildError("Finding number of %s tests in regression test summary failed",
+                                         test_result.lower())
                 else:
                     cnt = int(res.group('cnt'))
 
-                logmsg = msg % (cnt, test_result.lower())
+                logmsg = "Regression test reported %s / %s %s tests"
+                logmsg_values = (cnt, tot_cnt, test_result.lower())
 
                 # failed tests indicate problem with installation
                 # wrong tests are only an issue when there are excessively many
                 if (test_result == "FAILED" and cnt > 0) or (test_result == "WRONG" and (cnt / tot_cnt) > 0.1):
                     if self.cfg['ignore_regtest_fails']:
-                        self.log.warning(logmsg)
+                        self.log.warning(logmsg, *logmsg_values)
                         self.log.info("Ignoring failures in regression test, as requested.")
                     else:
-                        self.log.error(logmsg)
+                        raise EasyBuildError(logmsg, *logmsg_values)
                 elif test_result == "CORRECT" or cnt == 0:
-                    self.log.info(logmsg)
+                    self.log.info(logmsg, *logmsg_values)
                 else:
-                    self.log.warning(logmsg)
+                    self.log.warning(logmsg, *logmsg_values)
 
                 return postmsg
 
@@ -752,7 +755,7 @@ class EB_CP2K(EasyBlock):
                 if os.path.isfile(exefile):
                     shutil.copy2(exefile, targetdir)
         except OSError, err:
-            self.log.error("Copying executables from %s to bin dir %s failed: %s" % (exedir, targetdir, err))
+            raise EasyBuildError("Copying executables from %s to bin dir %s failed: %s", exedir, targetdir, err)
 
         # copy tests
         srctests = os.path.join(self.cfg['start_dir'], 'tests')
@@ -763,7 +766,7 @@ class EB_CP2K(EasyBlock):
             try:
                 shutil.copytree(srctests, targetdir)
             except:
-                self.log.error("Copying tests from %s to %s failed" % (srctests, targetdir))
+                raise EasyBuildError("Copying tests from %s to %s failed", srctests, targetdir)
 
         # copy regression test results
         if self.cfg['runtest']:
@@ -777,7 +780,7 @@ class EB_CP2K(EasyBlock):
                         self.log.info("Regression test results dir %s copied to %s" % (d, self.installdir))
                         break
             except (OSError, IOError), err:
-                self.log.error("Failed to copy regression test results dir: %s" % err)
+                raise EasyBuildError("Failed to copy regression test results dir: %s", err)
 
     def sanity_check_step(self):
         """Custom sanity check for CP2K"""

--- a/easybuild/easyblocks/c/cplex.py
+++ b/easybuild/easyblocks/c/cplex.py
@@ -39,6 +39,7 @@ import stat
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.binary import Binary
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd_qa
 
 
@@ -63,7 +64,7 @@ class EB_CPLEX(Binary):
             os.makedirs(tmpdir)
             os.makedirs(stagedir)
         except OSError, err:
-            self.log.exception("Failed to prepare for installation: %s" % err)
+            raise EasyBuildError("Failed to prepare for installation: %s", err)
 
         env.setvar('IATEMPDIR', tmpdir)
         dst = os.path.join(self.builddir, self.src[0]['name'])
@@ -89,7 +90,7 @@ class EB_CPLEX(Binary):
         try:
             os.chmod(self.installdir, stat.S_IRWXU | stat.S_IXOTH | stat.S_IXGRP | stat.S_IROTH | stat.S_IRGRP)
         except OSError, err:
-            self.log.exception("Can't set permissions on %s: %s" % (self.installdir, err))
+            raise EasyBuildError("Can't set permissions on %s: %s", self.installdir, err)
 
     def post_install_step(self):
         """Determine bin directory for this CPLEX installation."""
@@ -104,9 +105,9 @@ class EB_CPLEX(Binary):
         if len(bins) == 1:
             self.bindir = bins[0]
         elif len(bins) > 1:
-            self.log.error("More than one possible path for bin found: %s" % bins)
+            raise EasyBuildError("More than one possible path for bin found: %s", bins)
         else:
-            self.log.error("No bins found using %s in %s" % (binglob, self.installdir))
+            raise EasyBuildError("No bins found using %s in %s", binglob, self.installdir)
 
     def make_module_extra(self):
         """Add installdir to path and set CPLEX_HOME"""

--- a/easybuild/easyblocks/c/cufflinks.py
+++ b/easybuild/easyblocks/c/cufflinks.py
@@ -23,6 +23,7 @@ import os
 import sys
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 
 
@@ -37,7 +38,7 @@ class EB_Cufflinks(ConfigureMake):
         """
         for dep in ['Boost', 'Eigen', 'SAMtools']:
             if not get_software_root(dep):
-                self.log.error("Dependency module %s not loaded?" % dep)
+                raise EasyBuildError("Dependency module %s not loaded?", dep)
 
         super(EB_Cufflinks, self).configure_step()
 

--- a/easybuild/easyblocks/d/db.py
+++ b/easybuild/easyblocks/d/db.py
@@ -31,6 +31,7 @@ import os
 import shutil
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 
 
 class EB_DB(ConfigureMake):
@@ -41,5 +42,5 @@ class EB_DB(ConfigureMake):
         try:
             os.chdir('build_unix')
         except OSError, err:
-            self.log.error("Failed to move to build dir: %s" % err)
+            raise EasyBuildError("Failed to move to build dir: %s", err)
         super(EB_DB, self).configure_step(cmd_prefix='../dist/')

--- a/easybuild/easyblocks/d/dolfin.py
+++ b/easybuild/easyblocks/d/dolfin.py
@@ -35,6 +35,7 @@ import tempfile
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.cmakepythonpackage import CMakePythonPackage
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import rmtree2
 from easybuild.tools.modules import get_software_root, get_software_version
 
@@ -86,7 +87,7 @@ class EB_DOLFIN(CMakePythonPackage):
             self.cfg.update('configopts', ' -DMPI_LIBRARY="%s"' % os.getenv('MPI_LIB_SHARED'))
             self.cfg.update('configopts', ' -DMPI_INCLUDE_PATH="%s"' % os.getenv('MPI_INC_DIR'))
         else:
-            self.log.error('MPI_LIB_SHARED or MPI_INC_DIR not set, could not determine MPI-related paths.')
+            raise EasyBuildError("MPI_LIB_SHARED or MPI_INC_DIR not set, could not determine MPI-related paths.")
 
         # save config options to reuse them later (e.g. for sanity check commands)
         self.saved_configopts = self.cfg['configopts']
@@ -98,7 +99,7 @@ class EB_DOLFIN(CMakePythonPackage):
         for dep in deps:
             deproot = get_software_root(dep)
             if not deproot:
-                self.log.error("Dependency %s not available." % dep)
+                raise EasyBuildError("Dependency %s not available.", dep)
             else:
                 depsdict.update({dep:deproot})
 
@@ -170,7 +171,7 @@ class EB_DOLFIN(CMakePythonPackage):
         # make sure that all optional packages are found
         not_found_re = re.compile("The following optional packages could not be found")
         if not_found_re.search(out):
-            self.log.error("Optional packages could not be found, this should not happen...")
+            raise EasyBuildError("Optional packages could not be found, this should not happen...")
 
         # enable verbose build, so we have enough information if something goes wrong
         self.cfg.update('buildopts', "VERBOSE=1")
@@ -212,7 +213,7 @@ class EB_DOLFIN(CMakePythonPackage):
             os.makedirs(instant_cache_dir)
             os.makedirs(instant_error_dir)
         except OSError, err:
-            self.log.error("Failed to create Instant cache/error dirs: %s" % err)
+            raise EasyBuildError("Failed to create Instant cache/error dirs: %s", err)
 
         # keep track of $LDFLAGS, so we can restore them for the sanity check commands
         # this is required to make sure that linking of libraries (OpenBLAS, etc.) works as expected
@@ -281,4 +282,4 @@ class EB_DOLFIN(CMakePythonPackage):
         try:
             rmtree2(tmpdir)
         except OSError, err:
-            self.log.error("Failed to remove Instant cache/error dirs: %s" % err)
+            raise EasyBuildError("Failed to remove Instant cache/error dirs: %s", err)

--- a/easybuild/easyblocks/e/eigen.py
+++ b/easybuild/easyblocks/e/eigen.py
@@ -21,6 +21,7 @@ import os
 import shutil
 
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.build_log import EasyBuildError
 
 
 class EB_Eigen(EasyBlock):
@@ -50,7 +51,7 @@ class EB_Eigen(EasyBlock):
                 os.makedirs(os.path.dirname(destdir))
                 shutil.copytree(srcdir, destdir)
         except OSError, err:
-            self.log.error("Copying %s to installation dir %s failed: %s" % (srcdir, destdir, err))
+            raise EasyBuildError("Copying %s to installation dir %s failed: %s", srcdir, destdir, err)
 
     def sanity_check_step(self):
         """Custom sanity check for Eigen."""

--- a/easybuild/easyblocks/f/fdtd_solutions.py
+++ b/easybuild/easyblocks/f/fdtd_solutions.py
@@ -32,6 +32,7 @@ import os
 import shutil
 from easybuild.easyblocks.generic.rpm import rebuild_rpm
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd_qa
 
 
@@ -47,20 +48,20 @@ class EB_FDTD_underscore_Solutions(EasyBlock):
         # locate RPM and rebuild it to make it relocatable
         rpms = glob.glob(os.path.join(self.cfg['start_dir'], 'rpm_install_files', 'FDTD-%s*.rpm' % self.version))
         if len(rpms) != 1:
-            self.log.error("Incorrect number of RPMs found, was expecting exactly one: %s" % rpms)
+            raise EasyBuildError("Incorrect number of RPMs found, was expecting exactly one: %s", rpms)
         rebuilt_dir = os.path.join(self.cfg['start_dir'], 'rebuilt')
         rebuild_rpm(rpms[0], rebuilt_dir)
 
         # replace original RPM with relocatable RPM
         rebuilt_rpms = glob.glob(os.path.join(rebuilt_dir, '*', '*.rpm'))
         if len(rebuilt_rpms) != 1:
-            self.log.error("Incorrect number of rebuilt RPMs found, was expecting exactly one: %s" % rebuilt_rpms)
+            raise EasyBuildError("Incorrect number of rebuilt RPMs found, was expecting exactly one: %s", rebuilt_rpms)
 
         try:
             os.rename(rpms[0], '%s.bk' % rpms[0])
             shutil.copy2(rebuilt_rpms[0], rpms[0])
         except OSError, err:
-            self.log.error("Failed to replace original RPM with rebuilt RPM: %s" % err)
+            raise EasyBuildError("Failed to replace original RPM with rebuilt RPM: %s", err)
 
     def install_step(self):
         """Install FDTD Solutions using install.sh script."""

--- a/easybuild/easyblocks/f/ferret.py
+++ b/easybuild/easyblocks/f/ferret.py
@@ -37,6 +37,7 @@ EasyBuild support for building and installing Ferret, implemented as an easybloc
 import os,re,fileinput,sys
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
 
@@ -51,13 +52,13 @@ class EB_Ferret(ConfigureMake):
         try:
             os.chdir('FERRET')
         except OSError, err:
-            self.log.error("Failed to change to FERRET dir: %s" % err)
+            raise EasyBuildError("Failed to change to FERRET dir: %s", err)
 
         deps = ['HDF5', 'netCDF', 'Java']
 
         for name in deps:
             if not get_software_root(name):
-                self.log.error("%s module not loaded?" % name)
+                raise EasyBuildError("%s module not loaded?", name)
 
         fn = "site_specific.mk"
 

--- a/easybuild/easyblocks/f/flex.py
+++ b/easybuild/easyblocks/f/flex.py
@@ -31,6 +31,8 @@ EasyBuild support for building and installing flex, implemented as an easyblock
 import os
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
+
 
 class EB_flex(ConfigureMake):
     """Support for building and installing flex."""
@@ -47,7 +49,7 @@ class EB_flex(ConfigureMake):
                     os.symlink(os.path.join(self.installdir, "bin", "flex"), binpath)
 
         except OSError, err:
-            self.log.error("Failed to symlink binaries: %s" % err)
+            raise EasyBuildError("Failed to symlink binaries: %s", err)
 
     def sanity_check_step(self):
         """Custom sanity check for flex"""

--- a/easybuild/easyblocks/f/foldx.py
+++ b/easybuild/easyblocks/f/foldx.py
@@ -32,6 +32,7 @@ import shutil
 import stat
 
 from easybuild.easyblocks.generic.tarball import Tarball
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import adjust_permissions
 
 
@@ -65,5 +66,5 @@ class EB_FoldX(Tarball):
                 else:
                     self.log.warning("Skipping non-file %s in %s, not copying it." % (item, self.cfg['start_dir']))
         except OSError, err:
-            self.log.exception("Copying binaries in %s to install dir 'bin' failed: %s" % (self.cfg['start_dir'], err))
+            raise EasyBuildError("Copying binaries in %s to install dir 'bin' failed: %s", self.cfg['start_dir'], err)
 

--- a/easybuild/easyblocks/f/freesurfer.py
+++ b/easybuild/easyblocks/f/freesurfer.py
@@ -33,6 +33,7 @@ import os
 from easybuild.easyblocks.generic.tarball import Tarball
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import MANDATORY
+from easybuild.tools.build_log import EasyBuildError
 
 
 class EB_FreeSurfer(Tarball):
@@ -53,7 +54,7 @@ class EB_FreeSurfer(Tarball):
             f.write(self.cfg['license_text'])
             f.close()
         except IOError, err:
-            self.log.error("Failed to install license file: %s" % err)
+            raise EasyBuildError("Failed to install license file: %s", err)
 
     def make_module_extra(self):
         """Add setting of FREESURFER_HOME in module."""

--- a/easybuild/easyblocks/f/fsl.py
+++ b/easybuild/easyblocks/f/fsl.py
@@ -35,6 +35,7 @@ import shutil
 
 import easybuild.tools.environment as env
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
 
 
@@ -77,7 +78,7 @@ class EB_FSL(EasyBlock):
                 shutil.copytree(srcdir, tgtdir)
                 self.log.debug("Copied %s to %s" % (srcdir, tgtdir))
         except OSError, err:
-            self.log.error("Failed to copy closest matching config dir: %s" % err)
+            raise EasyBuildError("Failed to copy closest matching config dir: %s", err)
 
     def build_step(self):
         """Build FSL using supplied script."""
@@ -93,7 +94,7 @@ class EB_FSL(EasyBlock):
 
         error_regexp = re.compile("ERROR in BUILD")
         if error_regexp.search(txt):
-            self.log.error("Error detected in build log %s." % buildlog)
+            raise EasyBuildError("Error detected in build log %s.", buildlog)
 
     def install_step(self):
         """Building was performed in install dir, no explicit install step required."""

--- a/easybuild/easyblocks/g/g2clib.py
+++ b/easybuild/easyblocks/g/g2clib.py
@@ -37,6 +37,7 @@ import os
 import shutil
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 
 
@@ -52,7 +53,7 @@ class EB_g2clib(ConfigureMake):
 
         jasper = get_software_root('JASPER')
         if not jasper:
-            self.log.error("JasPer module not loaded?")
+            raise EasyBuildError("JasPer module not loaded?")
 
         # beware: g2clib uses INC, while g2lib uses INCDIR !
         buildopts = 'CC="%s" FC="%s" INC="-I%s/include"' % (os.getenv('CC'), os.getenv('F90'), jasper)
@@ -79,7 +80,7 @@ class EB_g2clib(ConfigureMake):
                                 os.path.join(targetdir, fn))
 
         except OSError, err:
-            self.log.error("Failed to copy files to install dir: %s" % err)
+            raise EasyBuildError("Failed to copy files to install dir: %s", err)
 
     def sanity_check_step(self):
         """Custom sanity check for g2clib."""

--- a/easybuild/easyblocks/g/g2lib.py
+++ b/easybuild/easyblocks/g/g2lib.py
@@ -36,6 +36,7 @@ import os
 import shutil
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 
 
@@ -51,7 +52,7 @@ class EB_g2lib(ConfigureMake):
 
         jasper = get_software_root('JASPER')
         if not jasper:
-            self.log.error("JasPer module not loaded?")
+            raise EasyBuildError("JasPer module not loaded?")
 
         buildopts = 'CC="%s" FC="%s" INCDIR="-I%s/include"' % (os.getenv('CC'), os.getenv('F90'), jasper)
         self.cfg.update('buildopts', buildopts)
@@ -67,7 +68,7 @@ class EB_g2lib(ConfigureMake):
             fn = "libg2.a"
             shutil.copyfile(os.path.join(self.cfg['start_dir'], fn), os.path.join(targetdir, fn))
         except OSError, err:
-            self.log.error("Failed to copy files to install dir: %s" % err)
+            raise EasyBuildError("Failed to copy files to install dir: %s", err)
 
     def sanity_check_step(self):
         """Custom sanity check for g2lib."""

--- a/easybuild/easyblocks/g/gate.py
+++ b/easybuild/easyblocks/g/gate.py
@@ -40,6 +40,7 @@ import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
 
 
@@ -97,14 +98,14 @@ class EB_GATE(CMakeMake):
             try:
                 os.chdir(os.path.join(os.path.join(self.cfg['start_dir'], subdir)))
             except OSError, err:
-                self.log.error("Failed to move to %s: %s" % (subdir, err))
+                raise EasyBuildError("Failed to move to %s: %s", subdir, err)
 
             super(EB_GATE, self).build_step()
 
         try:
             os.chdir(self.cfg['start_dir'])
         except OSError, err:
-            self.log.error("Failed to return to start dir %s: %s" % (self.cfg['start_dir'], err))
+            raise EasyBuildError("Failed to return to start dir %s: %s", self.cfg['start_dir'], err)
 
     def install_step(self):
         """Custom installation procedure for GATE."""
@@ -116,7 +117,7 @@ class EB_GATE(CMakeMake):
                 try:
                     os.chdir(os.path.join(os.path.join(self.cfg['start_dir'], subdir)))
                 except OSError, err:
-                    self.log.error("Failed to move to %s: %s" % (subdir, err))
+                    raise EasyBuildError("Failed to move to %s: %s", subdir, err)
 
                 super(EB_GATE, self).install_step()
         else:
@@ -127,7 +128,7 @@ class EB_GATE(CMakeMake):
                 shutil.rmtree(self.installdir)
                 shutil.copytree(self.cfg['start_dir'], self.installdir)
             except OSError, err:
-                self.log.error("Failed to copy %s to %s: %s" % (self.cfg['start_dir'], self.installdir, err))
+                raise EasyBuildError("Failed to copy %s to %s: %s", self.cfg['start_dir'], self.installdir, err)
 
             cmd = "source %s &> /dev/null && echo $G4SYSTEM" % os.path.join(self.cfg['start_dir'], 'env_gate.sh')
             out, _ = run_cmd(cmd, simple=False)
@@ -135,7 +136,7 @@ class EB_GATE(CMakeMake):
             if self.g4system:
                 self.log.debug("Value obtained for $G4SYSTEM: %s" % self.g4system)
             else:
-                self.log.error("Failed to obtain value for $G4SYSTEM, not set?")
+                raise EasyBuildError("Failed to obtain value for $G4SYSTEM, not set?")
 
             # copy Gate libraries to 'lib' subdir in installation directory
             try:
@@ -147,14 +148,14 @@ class EB_GATE(CMakeMake):
                         shutil.copy2(os.path.join(srclibdir, fil), os.path.join(libdir, fil))
                         self.log.debug("Copied library %s to 'lib' install subdirectory" % fil)
             except OSError, err:
-                self.log.error("Failed to copy GATE library/ies to lib directory: %s" % err)
+                raise EasyBuildError("Failed to copy GATE library/ies to lib directory: %s", err)
 
             # add link from tmp/<OS>-<comp>/gjs to lib
             js_dir = os.path.join(self.installdir, 'cluster_tools', 'jobsplitter')
             try:
                 os.symlink(os.path.join(js_dir, 'tmp', self.g4system, 'gjs'), os.path.join(js_dir, 'lib'))
             except OSError, err:
-                self.log.error("Failed to symlink tmp js dir to lib in %s: %s" % (js_dir, err))
+                raise EasyBuildError("Failed to symlink tmp js dir to lib in %s: %s", js_dir, err)
 
     def make_module_extra(self):
         """Overwritten from Application to add extra txt"""

--- a/easybuild/easyblocks/g/geant4.py
+++ b/easybuild/easyblocks/g/geant4.py
@@ -40,6 +40,7 @@ from distutils.version import LooseVersion
 import easybuild.tools.environment as env
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd, run_cmd_qa
 from easybuild.tools.filetools import mkdir
@@ -226,16 +227,16 @@ class EB_Geant4(CMakeMake):
                 scriptdirbase = os.path.join(pwd, '.config', 'bin')
                 filelist = os.listdir(scriptdirbase)
             except OSError, err:
-                self.log.error("Failed to determine self.g4system: %s" % err)
+                raise EasyBuildError("Failed to determine self.g4system: %s", err)
     
             if len(filelist) != 1:
-                self.log.error("Exactly one directory is expected in %s; found back: %s" % (scriptdirbase, filelist))
+                raise EasyBuildError("Exactly one directory is expected in %s; found back: %s", scriptdirbase, filelist)
             else:
                 self.g4system = filelist[0]
     
             self.scriptdir = os.path.join(scriptdirbase, self.g4system)
             if not os.path.isdir(self.scriptdir):
-                self.log.error("Something went wrong. Dir: %s doesn't exist." % self.scriptdir)
+                raise EasyBuildError("Something went wrong. Dir: %s doesn't exist.", self.scriptdir)
             self.log.info("The directory containing several important scripts to be copied was found: %s" % self.scriptdir)
 
             # copying config.sh to pwd
@@ -243,7 +244,7 @@ class EB_Geant4(CMakeMake):
                 self.log.info("copying config.sh to %s" % pwd)
                 shutil.copy2(os.path.join(self.scriptdir, 'config.sh'), pwd)
             except IOError, err:
-                self.log.error("Failed to copy config.sh to %s" % pwd)
+                raise EasyBuildError("Failed to copy config.sh to %s", pwd)
 
             # creating several scripts containing environment variables
             cmd = "%s/Configure -S -f config.sh -D g4conf=%s -D abssrc=%s" % (pwd, self.scriptdir, pwd)
@@ -278,7 +279,7 @@ class EB_Geant4(CMakeMake):
                     try:
                         os.symlink(source, target)
                     except OSError, err:
-                        self.log.error("Failed to symlink %s to %s: %s" % (source, target, err))
+                        raise EasyBuildError("Failed to symlink %s to %s: %s", source, target, err)
         else:
             pwd = self.cfg['start_dir']
 
@@ -287,7 +288,7 @@ class EB_Geant4(CMakeMake):
                 self.datadst = os.path.join(self.installdir, 'data')
                 os.mkdir(self.datadst)
             except OSError, err:
-                self.log.error("Failed to create data destination file %s: %s" % (self.datadst, err))
+                raise EasyBuildError("Failed to create data destination file %s: %s", self.datadst, err)
 
             datalist = ['G4ABLA%s' % self.cfg['G4ABLAVersion'],
                         'G4EMLOW%s' % self.cfg['G4EMLOWVersion'],
@@ -300,31 +301,31 @@ class EB_Geant4(CMakeMake):
                     self.log.info("Copying %s to %s" % (dat, self.datadst))
                     shutil.copytree(os.path.join(datasrc, dat), os.path.join(self.datadst, dat))
             except IOError, err:
-                self.log.error("Something went wrong during data copying (%s) to %s: %s" % (dat, self.datadst, err))
+                raise EasyBuildError("Something went wrong during data copying (%s) to %s: %s", dat, self.datadst, err)
 
             try:
                 for fil in ['config', 'environments', 'examples']:
                     self.log.info("Copying %s to %s" % (fil, self.installdir))
                     if not os.path.exists(os.path.join(pwd, fil)):
-                        self.log.error("No such file or directory: %s" % fil)
+                        raise EasyBuildError("No such file or directory: %s", fil)
                     if os.path.isdir(os.path.join(pwd, fil)):
                         shutil.copytree(os.path.join(pwd, fil), os.path.join(self.installdir, fil))
                     elif os.path.isfile(os.path.join(pwd, fil)):
                         shutil.copy2(os.path.join(pwd, fil), os.path.join(self.installdir, fil))
             except IOError, err:
-                self.log.error("Something went wrong during copying of %s to %s: %s" % (fil, self.installdir, err))
+                raise EasyBuildError("Something went wrong during copying of %s to %s: %s", fil, self.installdir, err)
 
             try:
                 for fil in ['config.sh', 'env.sh', 'env.csh']:
                     self.log.info("Copying %s to %s" % (fil, self.installdir))
                     if not os.path.exists(os.path.join(self.scriptdir, fil)):
-                        self.log.error("No such file or directory: %s" % fil)
+                        raise EasyBuildError("No such file or directory: %s", fil)
                     if os.path.isdir(os.path.join(self.scriptdir, fil)):
                         shutil.copytree(os.path.join(self.scriptdir, fil), os.path.join(self.installdir, fil))
                     elif os.path.isfile(os.path.join(self.scriptdir, fil)):
                         shutil.copy2(os.path.join(self.scriptdir, fil), os.path.join(self.installdir, fil))
             except IOError, err:
-                self.log.error("Something went wrong during copying of (%s) to %s: %s" % (fil, self.installdir, err))
+                raise EasyBuildError("Something went wrong during copying of (%s) to %s: %s", fil, self.installdir, err)
 
             cmd = "%(pwd)s/Configure -f %(pwd)s/config.sh -d -install" % {'pwd': pwd}
             run_cmd(cmd, log_all=True, simple=True)

--- a/easybuild/easyblocks/g/genomeanalysistk.py
+++ b/easybuild/easyblocks/g/genomeanalysistk.py
@@ -37,6 +37,7 @@ import os
 import shutil
 
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.build_log import EasyBuildError
 
 
 class EB_GenomeAnalysisTK(EasyBlock):
@@ -69,7 +70,7 @@ class EB_GenomeAnalysisTK(EasyBlock):
                     shutil.copy2(src, dst)
                     self.log.info("Successfully copied %s to %s" % (src, dst))
             except OSError, err:
-                self.log.error("Failed to copy %s to %s: %s" % (src, dst, err))
+                raise EasyBuildError("Failed to copy %s to %s: %s", src, dst, err)
 
         for subdir in ['resources']:
             try:
@@ -81,7 +82,7 @@ class EB_GenomeAnalysisTK(EasyBlock):
                     self.log.warning("No directory %s, so not copying it." % src_dir)
                 self.log.info("Successfully copied %s to %s" % (src_dir, dst_dir))
             except OSError, err:
-                self.log.error("Failed to copy %s to %s: %s" % (src_dir, dst_dir, err))
+                raise EasyBuildError("Failed to copy %s to %s: %s", src_dir, dst_dir, err)
 
     def sanity_check_step(self):
         """Custom sanity check for GenomeAnalysisTK"""

--- a/easybuild/easyblocks/g/go.py
+++ b/easybuild/easyblocks/g/go.py
@@ -32,6 +32,7 @@ import os
 import shutil
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import rmtree2
 from easybuild.tools.run import run_cmd
 
@@ -56,7 +57,7 @@ class EB_Go(ConfigureMake):
         try:
             os.chdir(srcdir)
         except OSError, err:
-            self.log.error("Failed to move to %s: %s" % (srcdir, err))
+            raise EasyBuildError("Failed to move to %s: %s", srcdir, err)
 
         # $GOROOT_FINAL only specifies the location of the final installation, which gets baked into the binaries
         # the installation itself is *not* done by the all.bash script, that needs to be done manually
@@ -67,4 +68,4 @@ class EB_Go(ConfigureMake):
             rmtree2(self.installdir)
             shutil.copytree(self.cfg['start_dir'], self.installdir, symlinks=self.cfg['keepsymlinks'])
         except OSError, err:
-            self.log.error("Failed to copy installation to %s: %s" % (self.installdir, err))
+            raise EasyBuildError("Failed to copy installation to %s: %s", self.installdir, err)

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -34,6 +34,7 @@ from vsc.utils.missing import any
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 
 
@@ -45,7 +46,7 @@ class EB_GROMACS(CMakeMake):
 
         if LooseVersion(self.version) < LooseVersion('4.6'):
             self.log.info("Using configure script for configuring GROMACS build.")
-            self.log.error("Configuration procedure for older GROMACS versions not implemented yet.")
+            raise EasyBuildError("Configuration procedure for older GROMACS versions not implemented yet.")
         else:
             # build a release build
             self.cfg.update('configopts', "-DCMAKE_BUILD_TYPE=Release")
@@ -115,7 +116,7 @@ class EB_GROMACS(CMakeMake):
             for pattern in patterns:
                 regex = re.compile(pattern, re.M)
                 if not regex.search(out):
-                    self.log.error("Pattern '%s' not found in GROMACS configuration output." % pattern)
+                    raise EasyBuildError("Pattern '%s' not found in GROMACS configuration output.", pattern)
 
     def test_step(self):
         """Specify to running tests is done using 'make check'."""

--- a/easybuild/easyblocks/generic/binariestarball.py
+++ b/easybuild/easyblocks/generic/binariestarball.py
@@ -32,6 +32,7 @@ import shutil
 import stat
 
 from easybuild.easyblocks.generic.tarball import Tarball
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import adjust_permissions
 
 
@@ -55,5 +56,5 @@ class BinariesTarball(Tarball):
                 else:
                     self.log.warning("Skipping non-file %s in %s, not copying it." % (item, self.cfg['start_dir']))
         except OSError, err:
-            self.log.exception("Copying binaries in %s to install dir 'bin' failed: %s" % (self.cfg['start_dir'], err))
+            raise EasyBuildError("Copying binaries in %s to install dir 'bin' failed: %s", self.cfg['start_dir'], err)
 

--- a/easybuild/easyblocks/generic/binary.py
+++ b/easybuild/easyblocks/generic/binary.py
@@ -38,6 +38,7 @@ import stat
 
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import mkdir, rmtree2
 from easybuild.tools.run import run_cmd
 
@@ -83,7 +84,7 @@ class Binary(EasyBlock):
                 shutil.copy2(src, self.builddir)
                 os.chmod(dst, stat.S_IRWXU)
             except (OSError, IOError), err:
-                self.log.exception("Couldn't copy %s to %s: %s" % (src, self.builddir, err))
+                raise EasyBuildError("Couldn't copy %s to %s: %s", src, self.builddir, err)
 
     def configure_step(self):
         """No configuration, this is binary software"""
@@ -101,7 +102,7 @@ class Binary(EasyBlock):
                 rmtree2(self.installdir)
                 shutil.copytree(self.cfg['start_dir'], self.installdir)
             except OSError, err:
-                self.log.error("Failed to copy %s to %s: %s" % (self.cfg['start_dir'], self.installdir, err))
+                raise EasyBuildError("Failed to copy %s to %s: %s", self.cfg['start_dir'], self.installdir, err)
         else:
             cmd = ' '.join([self.cfg['preinstallopts'], self.cfg['install_cmd'], self.cfg['installopts']])
             self.log.info("Installing %s using command '%s'..." % (self.name, cmd))
@@ -118,8 +119,8 @@ class Binary(EasyBlock):
                     rmtree2(self.installdir)
                 shutil.copytree(staged_installdir, self.installdir)
             except OSError, err:
-                tup = (staged_installdir, self.installdir, err)
-                self.log.error("Failed to move staged install from %s to %s: %s" % tup)
+                raise EasyBuildError("Failed to move staged install from %s to %s: %s",
+                                     staged_installdir, self.installdir, err)
 
         super(Binary, self).post_install_step()
 

--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -36,6 +36,7 @@ import os
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.environment import setvar
 from easybuild.tools.run import run_cmd
 
@@ -72,7 +73,7 @@ class CMakeMake(ConfigureMake):
                 os.mkdir(objdir)
                 os.chdir(objdir)
             except OSError, err:
-                self.log.error("Failed to create separate build dir %s in %s: %s" % (objdir, os.getcwd(), err))
+                raise EasyBuildError("Failed to create separate build dir %s in %s: %s", objdir, os.getcwd(), err)
             default_srcdir = '..'
 
         if srcdir is None:

--- a/easybuild/easyblocks/generic/cmdcp.py
+++ b/easybuild/easyblocks/generic/cmdcp.py
@@ -31,6 +31,7 @@ import re
 
 from easybuild.easyblocks.generic.makecp import MakeCp
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
 
 
@@ -57,7 +58,7 @@ class CmdCp(MakeCp):
         try:
             os.chdir(self.cfg['start_dir'])
         except OSError, err:
-            self.log.error("Failed to move (back) to %s: %s" % (self.cfg['start_dir'], err))
+            raise EasyBuildError("Failed to move (back) to %s: %s", self.cfg['start_dir'], err)
 
         for src in self.src:
             src = src['path']
@@ -71,6 +72,7 @@ class CmdCp(MakeCp):
                     cmd = regex_cmd % {'source': src, 'target': target}
                     break
             if cmd is None:
-                self.log.error("No match for %s in %s, don't know which command to use." % (src, self.cfg['cmds_map']))
+                raise EasyBuildError("No match for %s in %s, don't know which command to use.",
+                                     src, self.cfg['cmds_map'])
 
             run_cmd(cmd, log_all=True, simple=True)

--- a/easybuild/easyblocks/generic/fortranpythonpackage.py
+++ b/easybuild/easyblocks/generic/fortranpythonpackage.py
@@ -35,6 +35,7 @@ import os
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
 
 
@@ -65,6 +66,6 @@ class FortranPythonPackage(PythonPackage):
             cmd = "%s python setup.py build --fcompiler=gnu95" % cmdprefix
 
         else:
-            self.log.error("Unknown family of compilers being used: %s" % comp_fam)
+            raise EasyBuildError("Unknown family of compilers being used: %s", comp_fam)
 
         run_cmd(cmd, log_all=True, simple=True)

--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -42,6 +42,7 @@ import glob
 import easybuild.tools.environment as env
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
 
 from vsc import fancylogger
@@ -122,7 +123,7 @@ class IntelBase(EasyBlock):
                 else:
                     shutil.rmtree(path)
         except OSError, err:
-            self.log.error("Cleaning up intel dir %s failed: %s" % (self.home_subdir_local, err))
+            raise EasyBuildError("Cleaning up intel dir %s failed: %s", self.home_subdir_local, err)
 
     def setup_local_home_subdir(self):
         """
@@ -159,7 +160,7 @@ class IntelBase(EasyBlock):
                 self.log.debug("Created symlink (2) %s to %s" % (self.home_subdir, self.home_subdir_local))
 
         except OSError, err:
-            self.log.error("Failed to symlink %s to %s: %s" % (self.home_subdir_local, self.home_subdir, err))
+            raise EasyBuildError("Failed to symlink %s to %s: %s", self.home_subdir_local, self.home_subdir, err)
 
     def configure_step(self):
         """Configure: handle license file and clean home dir."""
@@ -179,12 +180,12 @@ class IntelBase(EasyBlock):
             if self.license_file:
                 self.log.info("Using license file %s" % self.license_file)
             else:
-                self.log.error("No license file defined, maybe set one these env vars: %s" % env_var_names)
+                raise EasyBuildError("No license file defined, maybe set one these env vars: %s", env_var_names)
 
             # verify license path
             if not os.path.exists(self.license_file):
-                tup = (self.license_file, env_var_names)
-                self.log.error("%s not found; correct 'license_file', or define one of the these env vars: %s" % tup)
+                raise EasyBuildError("%s not found; correct 'license_file', or define one of the these env vars: %s",
+                                     self.license_file, env_var_names)
 
             # set default environment variable for license specification
             env.setvar(default_lic_env_var, self.license_file)
@@ -219,7 +220,7 @@ class IntelBase(EasyBlock):
                     self.log.info('Picked the first *.lic file from $%s: %s' % (lic_env_var, lic_files[0]))
 
             if not valid_license_specs:
-                self.log.error("Cannot find a valid license specification in %s" % license_specs)
+                raise EasyBuildError("Cannot find a valid license specification in %s", license_specs)
 
             # only retain one environment variable (by order of preference), retain all valid matches for that env var
             for lic_env_var in lic_env_vars:
@@ -234,11 +235,12 @@ class IntelBase(EasyBlock):
                         env.setvar(default_lic_env_var, self.license_file)
                     break
             if self.license_file is None or self.license_env_var is None:
-                self.log.error("self.license_file or self.license_env_var still None, something went horribly wrong...")
+                raise EasyBuildError("self.license_file or self.license_env_var still None, "
+                                     "something went horribly wrong...")
 
             self.cfg['license_file'] = self.license_file
             env.setvar(self.license_env_var, self.license_file)
-            self.log.info("Using Intel license specifications from $%s: %s" % (self.license_env_var, self.license_file))
+            self.log.info("Using Intel license specifications from $%s: %s", self.license_env_var, self.license_file)
 
         # clean home directory
         self.clean_home_subdir()
@@ -266,7 +268,7 @@ class IntelBase(EasyBlock):
         if lic_activation in lic_file_server_activations:
             lic_file_entry = "%(license_file_name)s=%(license_file)s"
         elif not self.cfg['license_activation'] in other_activations:
-            self.log.error("Unknown type of activation specified: %s (known :%s)" % (lic_activation, ACTIVATION_TYPES))
+            raise EasyBuildError("Unknown type of activation specified: %s (known :%s)", lic_activation, ACTIVATION_TYPES)
 
         silent = '\n'.join([
             "%(activation_name)s=%(activation)s",
@@ -289,7 +291,7 @@ class IntelBase(EasyBlock):
             if isinstance(silent_cfg_extras, dict):
                 silent += '\n'.join("%s=%s" % (key, value) for (key, value) in silent_cfg_extras.iteritems())
             else:
-                self.log.error("silent_cfg_extras needs to be a dict")
+                raise EasyBuildError("silent_cfg_extras needs to be a dict")
 
         # we should be already in the correct directory
         silentcfg = os.path.join(os.getcwd(), "silent.cfg")
@@ -298,7 +300,7 @@ class IntelBase(EasyBlock):
             f.write(silent)
             f.close()
         except:
-            self.log.exception("Writing silent cfg % failed" % silent)
+            raise EasyBuildError("Writing silent cfg, failed", silent)
         self.log.debug("Contents of %s:\n%s" % (silentcfg, silent))
 
         # workaround for mktmp: create tmp dir and use it
@@ -306,7 +308,7 @@ class IntelBase(EasyBlock):
         try:
             os.makedirs(tmpdir)
         except:
-            self.log.exception("Directory %s can't be created" % (tmpdir))
+            raise EasyBuildError("Directory %s can't be created", tmpdir)
         tmppathopt = ''
         if self.cfg['usetmppath']:
             env.setvar('TMP_PATH', tmpdir)
@@ -341,7 +343,7 @@ class IntelBase(EasyBlock):
                 shutil.move(source, target)
             shutil.rmtree(os.path.join(self.installdir, self.name))
         except OSError, err:
-            self.log.error("Failed to move contents of %s to %s: %s" % (subdir, self.installdir, err))
+            raise EasyBuildError("Failed to move contents of %s to %s: %s", subdir, self.installdir, err)
 
     def cleanup_step(self):
         """Cleanup leftover mess

--- a/easybuild/easyblocks/generic/makecp.py
+++ b/easybuild/easyblocks/generic/makecp.py
@@ -33,6 +33,8 @@ import glob
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import BUILD, MANDATORY
+from easybuild.tools.build_log import EasyBuildError
+
 
 class MakeCp(ConfigureMake):
     """
@@ -74,13 +76,13 @@ class MakeCp(ConfigureMake):
                         files_specs = fil[0]
                         target = os.path.join(self.installdir, fil[1])
                     else:
-                        self.log.error("Only tuples of format '([<source files>], <target dir>)' supported.")
+                        raise EasyBuildError("Only tuples of format '([<source files>], <target dir>)' supported.")
                 # 'src_file' or 'src_dir'
                 elif isinstance(fil, basestring):
                     files_specs = [fil]
                     target = self.installdir
                 else:
-                    self.log.error("Found neither string nor tuple as file to copy: '%s' (type %s)" % (fil, type(fil)))
+                    raise EasyBuildError("Found neither string nor tuple as file to copy: '%s' (type %s)", fil, type(fil))
 
                 if not os.path.exists(target):
                     os.makedirs(target)
@@ -100,7 +102,7 @@ class MakeCp(ConfigureMake):
 
                     # there should be at least one match per file spec
                     if not filepaths:
-                        self.log.error("No files matching '%s' found anywhere." % files_spec)
+                        raise EasyBuildError("No files matching '%s' found anywhere.", files_spec)
 
                     for filepath in filepaths:
                         # copy individual file
@@ -112,7 +114,7 @@ class MakeCp(ConfigureMake):
                             self.log.debug("Copying directory %s to %s" % (filepath, target))
                             shutil.copytree(filepath, os.path.join(target, os.path.basename(filepath)))
                         else:
-                            self.log.error("Can't copy non-existing path %s to %s" % (filepath, target))
+                            raise EasyBuildError("Can't copy non-existing path %s to %s", filepath, target)
 
         except OSError, err:
-            self.log.error("Copying %s to installation dir failed: %s" % (fil, err))
+            raise EasyBuildError("Copying %s to installation dir failed: %s", fil, err)

--- a/easybuild/easyblocks/generic/packedbinary.py
+++ b/easybuild/easyblocks/generic/packedbinary.py
@@ -32,6 +32,7 @@ import shutil
 
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.easyblocks.generic.binary import Binary
+from easybuild.tools.build_log import EasyBuildError
 
 
 class PackedBinary(Binary, EasyBlock):
@@ -56,7 +57,7 @@ class PackedBinary(Binary, EasyBlock):
                 elif os.path.isfile(srcpath):
                     shutil.copy2(srcpath, self.installdir)
                 else:
-                    self.log.error("Path %s is not a file nor a directory?" % srcpath)
+                    raise EasyBuildError("Path %s is not a file nor a directory?", srcpath)
         except OSError, err:
-            self.log.error("Failed to copy unpacked sources to install directory: %s" % err)
+            raise EasyBuildError("Failed to copy unpacked sources to install directory: %s", err)
 

--- a/easybuild/easyblocks/generic/perlmodule.py
+++ b/easybuild/easyblocks/generic/perlmodule.py
@@ -34,6 +34,7 @@ from easybuild.easyblocks.perl import EXTS_FILTER_PERL_MODULES, get_major_perl_v
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
 
 
@@ -72,8 +73,8 @@ class PerlModule(ExtensionEasyBlock, ConfigureMake):
         """Perform the actual Perl module build/installation procedure"""
 
         if not self.src:
-            self.log.error("No source found for Perl module %s, required for installation. (src: %s)" %
-                           (self.name, self.src))
+            raise EasyBuildError("No source found for Perl module %s, required for installation. (src: %s)",
+                                 self.name, self.src)
         ExtensionEasyBlock.run(self, unpack_src=True)
 
         self.install_perl_module()

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -40,6 +40,7 @@ import easybuild.tools.environment as env
 from easybuild.easyblocks.python import EXTS_FILTER_PYTHON_PACKAGES
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import mkdir, rmtree2
 from easybuild.tools.modules import get_software_version
 from easybuild.tools.run import run_cmd
@@ -50,7 +51,7 @@ def det_pylibdir():
     log = fancylogger.getLogger('det_pylibdir', fname=False)
     pyver = get_software_version('Python')
     if not pyver:
-        log.error("Python module not loaded.")
+        raise EasyBuildError("Python module not loaded.")
     else:
         # determine Python lib dir via distutils
         # use run_cmd, we can to talk to the active Python, not the system Python running EasyBuild
@@ -62,8 +63,8 @@ def det_pylibdir():
 
         # value obtained should start with specified prefix, otherwise something is very wrong
         if not out.startswith(prefix):
-            tup = (cmd, prefix, out, ec)
-            log.error("Output of %s does not start with specified prefix %s: %s (exit code %s)" % tup)
+            raise EasyBuildError("Output of %s does not start with specified prefix %s: %s (exit code %s)",
+                                 cmd, prefix, out, ec)
 
         pylibdir = out.strip()[len(prefix):]
         log.debug("Determined pylibdir using '%s': %s" % (cmd, pylibdir))
@@ -97,7 +98,7 @@ class PythonPackage(ExtensionEasyBlock):
 
         # make sure there's no site.cfg in $HOME, because setup.py will find it and use it
         if os.path.exists(os.path.join(expanduser('~'), 'site.cfg')):
-            self.log.error('Found site.cfg in your home directory (%s), please remove it.' % expanduser('~'))
+            raise EasyBuildError("Found site.cfg in your home directory (%s), please remove it.", expanduser('~'))
 
         if not 'modulename' in self.options:
             self.options['modulename'] = self.name.lower()
@@ -117,7 +118,7 @@ class PythonPackage(ExtensionEasyBlock):
         """Configure Python package build."""
 
         if not self.pylibdir:
-            self.log.error('Python module not loaded.')
+            raise EasyBuildError("Python module not loaded.")
         self.log.debug("Python library dir: %s" % self.pylibdir)
 
         if self.sitecfg is not None:
@@ -141,7 +142,7 @@ class PythonPackage(ExtensionEasyBlock):
                 config.write(finaltxt)
                 config.close()
             except IOError:
-                self.log.exception("Creating %s failed" % self.sitecfgfn)
+                raise EasyBuildError("Creating %s failed", self.sitecfgfn)
 
         # creates log entries for python being used, for debugging
         run_cmd("python -V")
@@ -171,7 +172,7 @@ class PythonPackage(ExtensionEasyBlock):
                     testinstalldir = tempfile.mkdtemp()
                     mkdir(os.path.join(testinstalldir, self.pylibdir), parents=True)
                 except OSError, err:
-                    self.log.error("Failed to create test install dir: %s" % err)
+                    raise EasyBuildError("Failed to create test install dir: %s", err)
 
                 tup = (self.cfg['preinstallopts'], testinstalldir, self.cfg['installopts'])
                 cmd = "%s python setup.py install --prefix=%s %s" % tup
@@ -188,7 +189,7 @@ class PythonPackage(ExtensionEasyBlock):
                 try:
                     rmtree2(testinstalldir)
                 except OSError, err:
-                    self.log.exception("Removing testinstalldir %s failed: %s" % (testinstalldir, err))
+                    raise EasyBuildError("Removing testinstalldir %s failed: %s", testinstalldir, err)
 
     def install_step(self):
         """Install Python package to a custom path using setup.py"""
@@ -214,8 +215,8 @@ class PythonPackage(ExtensionEasyBlock):
         """Perform the actual Python package build/installation procedure"""
 
         if not self.src:
-            self.log.error("No source found for Python package %s, required for installation. (src: %s)" % (self.name,
-                                                                                                            self.src))
+            raise EasyBuildError("No source found for Python package %s, required for installation. (src: %s)",
+                                 self.name, self.src)
         super(PythonPackage, self).run(unpack_src=True)
 
         # configure, build, test, install

--- a/easybuild/easyblocks/generic/rpackage.py
+++ b/easybuild/easyblocks/generic/rpackage.py
@@ -37,6 +37,7 @@ import shutil
 
 from easybuild.easyblocks.r import EXTS_FILTER_R_PACKAGES, EB_R
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd, parse_log_for_error
 
 
@@ -132,12 +133,12 @@ class RPackage(ExtensionEasyBlock):
         """Source should not be extracted."""
         pass
         if len(self.src) > 1:
-            self.log.error("Don't know how to handle R packages with multiple sources.'")
+            raise EasyBuildError("Don't know how to handle R packages with multiple sources.'")
         else:
             try:
                 shutil.copy2(self.src[0]['path'], self.builddir)
             except OSError, err:
-                self.log.error("Failed to copy source to build dir: %s" % err)
+                raise EasyBuildError("Failed to copy source to build dir: %s", err)
             self.ext_src = self.src[0]['name']
 
             # set final path since it can't be determined from unpacked sources (used for guessing start_dir)
@@ -165,7 +166,7 @@ class RPackage(ExtensionEasyBlock):
             # remove package if errors were detected
             # it's possible that some of the dependencies failed, but the package itself was installed
             run_cmd(cmd, log_all=False, log_ok=False, simple=False, inp=stdin, regexp=False)
-            self.log.error("Errors detected during installation of R package %s!" % self.name)
+            raise EasyBuildError("Errors detected during installation of R package %s!", self.name)
         else:
             self.log.debug("R package %s installed succesfully" % self.name)
 

--- a/easybuild/easyblocks/generic/tarball.py
+++ b/easybuild/easyblocks/generic/tarball.py
@@ -35,7 +35,9 @@ implemented as an easyblock
 import shutil
 
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import rmtree2
+
 
 class Tarball(EasyBlock):
     """
@@ -68,4 +70,4 @@ class Tarball(EasyBlock):
             # self.cfg['keepsymlinks'] is False by default except when explicitly put to True in .eb file
             shutil.copytree(src, self.installdir, symlinks=self.cfg['keepsymlinks'])
         except OSError, err:
-            self.log.error("Copying %s to installation dir %s failed: %s" % (src, self.installdir, err))
+            raise EasyBuildError("Copying %s to installation dir %s failed: %s", src, self.installdir, err)

--- a/easybuild/easyblocks/generic/versionindependentpythonpackage.py
+++ b/easybuild/easyblocks/generic/versionindependentpythonpackage.py
@@ -36,6 +36,7 @@ import re
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
 
 
@@ -61,7 +62,7 @@ class VersionIndependentPythonPackage(PythonPackage):
             os.mkdir(full_pylibdir)
         except OSError, err:
             # this will raise an error and not return
-            self.log.error("Failed to install: %s" % err)
+            raise EasyBuildError("Failed to install: %s", err)
 
         args = "--prefix=%s --install-lib=%s " % (self.installdir, full_pylibdir)
         args += "--single-version-externally-managed --record %s --no-compile" % os.path.join(self.builddir, 'record')
@@ -85,4 +86,4 @@ class VersionIndependentPythonPackage(PythonPackage):
                             txt = shebang_re.sub(new_shebang, txt)
                             open(script, 'w').write(txt)
                     except IOError, err:
-                        self.log.error("Failed to patch shebang header line in %s: %s" % (script, err))
+                        raise EasyBuildError("Failed to patch shebang header line in %s: %s", script, err)

--- a/easybuild/easyblocks/h/hdf5.py
+++ b/easybuild/easyblocks/h/hdf5.py
@@ -36,6 +36,7 @@ import os
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 
 
@@ -55,7 +56,7 @@ class EB_HDF5(ConfigureMake):
             if root:
                 self.cfg.update('configopts', '%s=%s' % (opt, root))
             else:
-                self.log.error("Dependency module %s not loaded." % dep)
+                raise EasyBuildError("Dependency module %s not loaded.", dep)
 
         fcomp = 'FC="%s"' % os.getenv('F90')
 

--- a/easybuild/easyblocks/h/hpcg.py
+++ b/easybuild/easyblocks/h/hpcg.py
@@ -33,6 +33,7 @@ import re
 import shutil
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import mkdir
 from easybuild.tools.run import run_cmd
 
@@ -70,17 +71,17 @@ class EB_HPCG(ConfigureMake):
         try:
             hpcg_logs = glob.glob('hpcg_log*txt')
             if len(hpcg_logs) == 1:
-                tup = (success_regex.pattern, hpcg_logs[0])
                 txt = open(hpcg_logs[0], 'r').read()
                 self.log.debug("Contents of HPCG log file %s: %s" % (hpcg_logs[0], txt))
                 if success_regex.search(txt):
-                    self.log.info("Found pattern '%s' in HPCG log file %s, OK!" % tup)
+                    self.log.info("Found pattern '%s' in HPCG log file %s, OK!", success_regex.pattern, hpcg_logs[0])
                 else:
-                    self.log.error("Failed to find pattern '%s' in HPCG log file %s" % tup)
+                    raise EasyBuildError("Failed to find pattern '%s' in HPCG log file %s",
+                                         success_regex.pattern, hpcg_logs[0])
             else:
-                self.log.error("Failed to find exactly one HPCG log file: %s" % hpcg_logs)
+                raise EasyBuildError("Failed to find exactly one HPCG log file: %s", hpcg_logs)
         except OSError, err:
-            self.log.error("Failed to check for success in HPCG log file: %s" % err)
+            raise EasyBuildError("Failed to check for success in HPCG log file: %s", err)
 
     def install_step(self):
         """Custom install procedure for HPCG."""
@@ -89,7 +90,7 @@ class EB_HPCG(ConfigureMake):
         try:
             shutil.copytree(objbindir, bindir)
         except OSError, err:
-            self.log.error("Failed to copy HPCG files to %s: %s" % (bindir, err))
+            raise EasyBuildError("Failed to copy HPCG files to %s: %s", bindir, err)
 
     def sanity_check_step(self):
         """Custom sanity check for HPCG."""

--- a/easybuild/easyblocks/h/hpl.py
+++ b/easybuild/easyblocks/h/hpl.py
@@ -36,6 +36,7 @@ import os
 import shutil
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
 
 
@@ -63,7 +64,7 @@ class EB_HPL(ConfigureMake):
         try:
             os.chdir(setupdir)
         except OSError, err:
-            self.log.exception("Failed to change to to dir %s: %s" % (setupdir, err))
+            raise EasyBuildError("Failed to change to to dir %s: %s", setupdir, err)
 
         cmd = "/bin/bash make_generic"
 
@@ -72,7 +73,7 @@ class EB_HPL(ConfigureMake):
         try:
             os.symlink(os.path.join(setupdir, 'Make.UNKNOWN'), os.path.join(makeincfile))
         except OSError, err:
-            self.log.exception("Failed to symlink Make.UNKNOWN from %s to %s: %s" % (setupdir, makeincfile, err))
+            raise EasyBuildError("Failed to symlink Make.UNKNOWN from %s to %s: %s", setupdir, makeincfile, err)
 
         # go back
         os.chdir(self.cfg['start_dir'])
@@ -84,7 +85,7 @@ class EB_HPL(ConfigureMake):
 
         for envvar in ['MPICC', 'LIBLAPACK_MT', 'CPPFLAGS', 'LDFLAGS', 'CFLAGS']:
             if not os.getenv(envvar):
-                self.log.error("Required environment variable %s not found (no toolchain used?)." % envvar)
+                raise EasyBuildError("Required environment variable %s not found (no toolchain used?).", envvar)
 
         # build dir
         extra_makeopts = 'TOPdir="%s" ' % self.cfg['start_dir']
@@ -121,7 +122,7 @@ class EB_HPL(ConfigureMake):
                 srcfile = os.path.join(srcdir, filename)
                 shutil.copy2(srcfile, destdir)
         except OSError, err:
-            self.log.exception("Copying %s to installation dir %s failed: %s" % (srcfile, destdir, err))
+            raise EasyBuildError("Copying %s to installation dir %s failed: %s", srcfile, destdir, err)
 
     def sanity_check_step(self):
         """

--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -43,6 +43,7 @@ import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.intelbase import IntelBase, ACTIVATION_NAME_2012, LICENSE_FILE_NAME_2012
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import rmtree2
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
@@ -98,7 +99,7 @@ class EB_imkl(IntelBase):
         """
         if LooseVersion(self.version) >= LooseVersion('10.3'):
             if self.cfg['m32']:
-                self.log.error("32-bit not supported yet for IMKL v%s (>= 10.3)" % self.version)
+                raise EasyBuildError("32-bit not supported yet for IMKL v%s (>= 10.3)", self.version)
             else:
                 retdict = {
                     'PATH': ['bin', 'mkl/bin', 'mkl/bin/intel64', 'composerxe-2011/bin'],
@@ -189,7 +190,7 @@ class EB_imkl(IntelBase):
                     f.close()
                     self.log.info("File %s written" % dest)
                 except IOError, err:
-                    self.log.exception("Can't write file %s: %s" % (dest, err))
+                    raise EasyBuildError("Can't write file %s: %s", dest, err)
 
         # build the mkl interfaces, if desired
         if self.cfg['interfaces']:
@@ -219,7 +220,7 @@ class EB_imkl(IntelBase):
                 os.chdir(interfacedir)
                 self.log.info("Changed to interfaces directory %s" % interfacedir)
             except OSError, err:
-                self.log.exception("Can't change to interfaces directory %s" % interfacedir)
+                raise EasyBuildError("Can't change to interfaces directory %s", interfacedir)
 
             compopt = None
             # determine whether we're using a non-Intel GCC-based toolchain
@@ -228,7 +229,8 @@ class EB_imkl(IntelBase):
                 if get_software_root('GCC'):
                     compopt = 'compiler=gnu'
                 else:
-                    self.log.error("Not using either Intel compilers nor GCC, don't know how to build wrapper libs")
+                    raise EasyBuildError("Not using either Intel compilers nor GCC, "
+                                         "don't know how to build wrapper libs")
             else:
                 compopt = 'compiler=intel'
 
@@ -293,12 +295,12 @@ class EB_imkl(IntelBase):
                         os.chdir(intdir)
                         self.log.info("Changed to interface %s directory %s" % (lib, intdir))
                     except OSError, err:
-                        self.log.error("Can't change to interface %s directory %s: %s" % (lib, intdir, err))
+                        raise EasyBuildError("Can't change to interface %s directory %s: %s", lib, intdir, err)
 
                     fullcmd = "%s %s" % (cmd, ' '.join(buildopts + extraopts))
                     res = run_cmd(fullcmd, log_all=True, simple=True)
                     if not res:
-                        self.log.error("Building %s (flags: %s, fullcmd: %s) failed" % (lib, flags, fullcmd))
+                        raise EasyBuildError("Building %s (flags: %s, fullcmd: %s) failed", lib, flags, fullcmd)
 
                     for fn in os.listdir(tmpbuild):
                         src = os.path.join(tmpbuild, fn)
@@ -312,7 +314,7 @@ class EB_imkl(IntelBase):
                                 shutil.move(src, dest)
                                 self.log.info("Moved %s to %s" % (src, dest))
                         except OSError, err:
-                            self.log.error("Failed to move %s to %s: %s" % (src, dest, err))
+                            raise EasyBuildError("Failed to move %s to %s: %s", src, dest, err)
 
                     rmtree2(tmpbuild)
 
@@ -329,7 +331,7 @@ class EB_imkl(IntelBase):
             if get_software_root('GCC'):
                 compsuff = '_gnu'
             else:
-                self.log.error("Not using Intel compilers or GCC, don't know compiler suffix for FFTW libraries.")
+                raise EasyBuildError("Not using Intel compilers or GCC, don't know compiler suffix for FFTW libraries.")
 
         if self.cfg['interfaces']:
             precs = ['_double', '_single']
@@ -356,7 +358,7 @@ class EB_imkl(IntelBase):
 
         if ver >= LooseVersion('10.3'):
             if self.cfg['m32']:
-                self.log.error("Sanity check for 32-bit not implemented yet for IMKL v%s (>= 10.3)" % self.version)
+                raise EasyBuildError("Sanity check for 32-bit not implemented yet for IMKL v%s (>= 10.3)", self.version)
             else:
                 mkldirs = ["bin", "mkl/bin", "mkl/bin/intel64", "mkl/lib/intel64", "mkl/include"]
                 libs += [lib % {'suff': suff} for lib in extralibs for suff in ['lp64', 'ilp64']]

--- a/easybuild/easyblocks/i/impi.py
+++ b/easybuild/easyblocks/i/impi.py
@@ -38,6 +38,7 @@ from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.intelbase import IntelBase, ACTIVATION_NAME_2012, LICENSE_FILE_NAME_2012
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
 
 
@@ -111,14 +112,14 @@ EULA=accept
                 f.write(silent)
                 f.close()
             except:
-                self.log.exception("Writing silent cfg file %s failed." % silent)
+                raise EasyBuildError("Writing silent cfg file %s failed.", silent)
             self.log.debug("Contents of %s: %s" % (silentcfg, silent))
 
             tmpdir = os.path.join(os.getcwd(), self.version, 'mytmpdir')
             try:
                 os.makedirs(tmpdir)
             except:
-                self.log.exception("Directory %s can't be created" % (tmpdir))
+                raise EasyBuildError("Directory %s can't be created", tmpdir)
 
             cmd = "./install.sh --tmp-dir=%s --silent=%s" % (tmpdir, silentcfg)
             run_cmd(cmd, log_all=True, simple=True)
@@ -186,7 +187,7 @@ EULA=accept
                 if val:
                     txt += self.module_generator.set_environment(target_var, val)
                 else:
-                    self.log.error("Environment variable $%s not set, can't define $%s" % (src_var, target_var))
+                    raise EasyBuildError("Environment variable $%s not set, can't define $%s", src_var, target_var)
 
         if self.cfg['set_mpi_wrapper_aliases_gcc'] or self.cfg['set_mpi_wrappers_all']:
             # force mpigcc/mpigxx to use GCC compilers, as would be expected based on their name

--- a/easybuild/easyblocks/i/itac.py
+++ b/easybuild/easyblocks/i/itac.py
@@ -91,8 +91,8 @@ EULA=accept
             tmpdir = os.path.join(os.getcwd(), self.version, 'mytmpdir')
             try:
                 os.makedirs(tmpdir)
-            except:
-                raise EasyBuildError("Directory %s can't be created", tmpdir)
+            except OSError, err:
+                raise EasyBuildError("Directory %s can't be created: %s", tmpdir, err)
 
             cmd = "./install.sh --tmp-dir=%s --silent=%s" % (tmpdir, silentcfg)
 

--- a/easybuild/easyblocks/i/itac.py
+++ b/easybuild/easyblocks/i/itac.py
@@ -38,6 +38,7 @@ from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.intelbase import IntelBase
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
 
 class EB_itac(IntelBase):
@@ -91,7 +92,7 @@ EULA=accept
             try:
                 os.makedirs(tmpdir)
             except:
-                self.log.exception("Directory %s can't be created" % (tmpdir))
+                raise EasyBuildError("Directory %s can't be created", tmpdir)
 
             cmd = "./install.sh --tmp-dir=%s --silent=%s" % (tmpdir, silentcfg)
 

--- a/easybuild/easyblocks/l/lapack.py
+++ b/easybuild/easyblocks/l/lapack.py
@@ -42,6 +42,7 @@ from easybuild.framework.easyconfig import CUSTOM
 from easybuild.toolchains.linalg.atlas import Atlas
 from easybuild.toolchains.linalg.gotoblas import GotoBLAS
 from easybuild.toolchains.linalg.openblas import OpenBLAS
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
 
@@ -67,7 +68,7 @@ def get_blas_lib(log):
             log.debug("%s module not loaded" % key)
 
     if not blaslib:
-        log.error("No or unknown BLAS lib loaded; known BLAS libs: %s" % known_blas_libs.keys())
+        raise EasyBuildError("No or unknown BLAS lib loaded; known BLAS libs: %s", known_blas_libs.keys())
 
     return blaslib
 
@@ -98,21 +99,21 @@ class EB_LAPACK(ConfigureMake):
         elif self.toolchain.comp_family() == toolchain.INTELCOMP:  #@UndefinedVariable
             makeinc = 'ifort'
         else:
-            self.log.error("Don't know which build_step.inc file to pick, unknown compiler being used...")
+            raise EasyBuildError("Don't know which build_step.inc file to pick, unknown compiler being used...")
 
         src = os.path.join(self.cfg['start_dir'], 'INSTALL', 'make.inc.%s' % makeinc)
         dest = os.path.join(self.cfg['start_dir'], 'make.inc')
 
         if not os.path.isfile(src):
-            self.log.error("Can't find source file %s" % src)
+            raise EasyBuildError("Can't find source file %s", src)
 
         if os.path.exists(dest):
-            self.log.error("Destination file %s exists" % dest)
+            raise EasyBuildError("Destination file %s exists", dest)
 
         try:
             shutil.copy(src, dest)
         except OSError, err:
-            self.log.error("Copying %s to %s failed: %s" % (src, dest, err))
+            raise EasyBuildError("Copying %s to %s failed: %s", src, dest, err)
 
         # set optimization flags
         fpic = ''
@@ -186,7 +187,7 @@ class EB_LAPACK(ConfigureMake):
                     os.symlink(frompath, topath)
 
         except OSError, err:
-            self.log.error("Copying %s to installation dir %s failed: %s" % (srcdir, destdir, err))
+            raise EasyBuildError("Copying %s to installation dir %s failed: %s", srcdir, destdir, err)
 
     def load_module(self, mod_paths=None, purge=True):
         """Don't try to load (non-existing) LAPACK module when performing a test build."""
@@ -200,7 +201,7 @@ class EB_LAPACK(ConfigureMake):
         if self.cfg['test_only']:
 
             if not get_software_root('LAPACK'):
-                self.log.error("You need to make sure that the LAPACK module is loaded to perform testing.")
+                raise EasyBuildError("You need to make sure that the LAPACK module is loaded to perform testing.")
 
             blaslib = get_blas_lib(self.log)
 

--- a/easybuild/easyblocks/l/libsmm.py
+++ b/easybuild/easyblocks/l/libsmm.py
@@ -39,6 +39,7 @@ from distutils.version import LooseVersion
 import easybuild.tools.toolchain as toolchain
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
 
@@ -68,7 +69,7 @@ class EB_libsmm(EasyBlock):
             os.chdir(dst)
             self.log.debug('Change to directory %s' % dst)
         except OSError, err:
-            self.log.exception('Failed to change to directory %s: %s' % (dst, err))
+            raise EasyBuildError("Failed to change to directory %s: %s", dst, err)
 
     def build_step(self):
         """Build libsmm
@@ -159,10 +160,10 @@ tasks=%(tasks)s
 
             targetcompile = "%s %s %s" % (hostcompile, opts, extra)
         else:
-            self.log.error('No supported compiler found (tried GCC)')
+            raise EasyBuildError("No supported compiler found (tried GCC)")
 
         if not os.getenv('LIBBLAS'):
-            self.log.error('No BLAS library specifications found (LIBBLAS not set)!')
+            raise EasyBuildError("No BLAS library specifications found (LIBBLAS not set)!")
 
         cfgdict = {
                    'datatype': None,
@@ -187,7 +188,7 @@ tasks=%(tasks)s
                 f.close()
                 self.log.debug("config file %s for datatype %s ('%s'): %s" % (fn, dt, descr, txt))
             except IOError, err:
-                self.log.error("Failed to write %s: %s" % (fn, err))
+                raise EasyBuildError("Failed to write %s: %s", fn, err)
 
             self.log.info("Building for datatype %s ('%s')..." % (dt, descr))
             run_cmd("./do_clean")
@@ -200,7 +201,7 @@ tasks=%(tasks)s
         try:
             shutil.copytree('lib', os.path.join(self.installdir, 'lib'))
         except Exception, err:
-            self.log.error("Something went wrong during dir lib copying to installdir: %s" % err)
+            raise EasyBuildError("Something went wrong during dir lib copying to installdir: %s", err)
 
     def sanity_check_step(self):
         """Custom sanity check for libsmm"""

--- a/easybuild/easyblocks/l/libxml2.py
+++ b/easybuild/easyblocks/l/libxml2.py
@@ -33,6 +33,7 @@ import os
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 
 
@@ -51,7 +52,7 @@ class EB_libxml2(ConfigureMake, PythonPackage):
         Test if python module is loaded
         """
         if not get_software_root('Python'):
-            self.log.error("Python module not loaded")
+            raise EasyBuildError("Python module not loaded")
        
         ConfigureMake.configure_step(self)
 
@@ -60,7 +61,7 @@ class EB_libxml2(ConfigureMake, PythonPackage):
             PythonPackage.configure_step(self)
             os.chdir('..')
         except OSError, err:
-            self.log.error("Failed to configure libxml2 Python bindings: %s" % err)
+            raise EasyBuildError("Failed to configure libxml2 Python bindings: %s", err)
 
     def build_step(self):
         """
@@ -75,7 +76,7 @@ class EB_libxml2(ConfigureMake, PythonPackage):
             PythonPackage.build_step(self)
             os.chdir('..')
         except OSError, err:
-            self.log.error("Failed to build libxml2 Python bindings: %s" % err)
+            raise EasyBuildError("Failed to build libxml2 Python bindings: %s", err)
 
     def install_step(self):
         """
@@ -88,7 +89,7 @@ class EB_libxml2(ConfigureMake, PythonPackage):
             PythonPackage.install_step(self)
             os.chdir('..')
         except OSError, err:
-            self.log.error("Failed to install libxml2 Python bindings: %s" % err)
+            raise EasyBuildError("Failed to install libxml2 Python bindings: %s", err)
 
     def make_module_extra(self):
         """

--- a/easybuild/easyblocks/m/mathematica.py
+++ b/easybuild/easyblocks/m/mathematica.py
@@ -31,6 +31,7 @@ import os
 
 from easybuild.easyblocks.generic.binary import Binary
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd_qa
 
 
@@ -49,7 +50,7 @@ class EB_Mathematica(Binary):
         """No configuration for Mathematica."""
         # ensure a license server is specified
         if self.cfg['license_server'] is None:
-            self.log.error("No license server specified.")
+            raise EasyBuildError("No license server specified.")
 
     def build_step(self):
         """No build step for Mathematica."""
@@ -87,7 +88,7 @@ class EB_Mathematica(Binary):
             f.close()
             self.log.info("Updated license file %s: %s" % (mathpass_path, mathpass_txt))
         except IOError, err:
-            self.log.error("Failed to update %s with license server info: %s" % (mathpass_path, err))
+            raise EasyBuildError("Failed to update %s with license server info: %s", mathpass_path, err)
 
         # restore $DISPLAY if required
         if orig_display is not None:

--- a/easybuild/easyblocks/m/matlab.py
+++ b/easybuild/easyblocks/m/matlab.py
@@ -39,6 +39,7 @@ import shutil
 
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
 
 
@@ -75,7 +76,7 @@ class EB_MATLAB(EasyBlock):
             f.write(lictxt)
             f.close()
         except IOError, err:
-            self.log.error("Failed to create license file %s: %s" % (licfile, err))
+            raise EasyBuildError("Failed to create license file %s: %s", licfile, err)
 
         configfile = os.path.join(self.builddir, self.configfilename)
         try:
@@ -100,7 +101,7 @@ class EB_MATLAB(EasyBlock):
             f.close()
 
         except IOError, err:
-            self.log.error("Failed to create installation config file %s: %s" % (configfile, err))
+            raise EasyBuildError("Failed to create installation config file %s: %s", configfile, err)
 
         self.log.debug('configuration file written to %s:\n %s' % (configfile, config))
 
@@ -121,7 +122,7 @@ class EB_MATLAB(EasyBlock):
             else:
                 self.log.info("Did not find source file %s" % src)
         except OSError, err:
-            self.log.error("Failed to chmod install script: %s" % err)
+            raise EasyBuildError("Failed to chmod install script: %s", err)
 
         # make sure $DISPLAY is not defined, which may lead to (hard to trace) problems
         # this is a workaround for not being able to specify --nodisplay to the install scripts

--- a/easybuild/easyblocks/m/metavelvet.py
+++ b/easybuild/easyblocks/m/metavelvet.py
@@ -21,6 +21,7 @@ import os
 import shutil
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 
 
 class EB_MetaVelvet(ConfigureMake):
@@ -48,7 +49,7 @@ class EB_MetaVelvet(ConfigureMake):
                 srcfile = os.path.join(srcdir, filename)
                 shutil.copy2(srcfile, destdir)
         except OSError, err:
-            self.log.error("Copying %s to installation dir %s failed: %s" % (srcfile, destdir, err))
+            raise EasyBuildError("Copying %s to installation dir %s failed: %s", srcfile, destdir, err)
 
     def sanity_check_step(self):
         """Custom sanity check for MetaVelvet."""

--- a/easybuild/easyblocks/m/metis.py
+++ b/easybuild/easyblocks/m/metis.py
@@ -36,6 +36,7 @@ import shutil
 from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import mkdir
 from easybuild.tools.run import run_cmd
 
@@ -84,7 +85,7 @@ class EB_METIS(ConfigureMake):
                 dst = os.path.join(libdir, 'libmetis.a')
                 shutil.copy2(src, dst)
             except OSError, err:
-                self.log.error("Copying file libmetis.a to lib dir failed: %s" % err)
+                raise EasyBuildError("Copying file libmetis.a to lib dir failed: %s", err)
 
             # copy include files
             try:
@@ -94,7 +95,7 @@ class EB_METIS(ConfigureMake):
                     shutil.copy2(src, dst)
                     os.chmod(dst, 0755)
             except OSError, err:
-                self.log.error("Copying file metis.h to include dir failed: %s" % err)
+                raise EasyBuildError("Copying file metis.h to include dir failed: %s", err)
 
             # other applications depending on ParMETIS (SuiteSparse for one) look for both ParMETIS libraries
             # and header files in the Lib directory (capital L). The following symlinks are hence created.
@@ -104,7 +105,7 @@ class EB_METIS(ConfigureMake):
                 for f in ['defs.h', 'macros.h', 'metis.h', 'proto.h', 'rename.h', 'struct.h']:
                     os.symlink(os.path.join(includedir, f), os.path.join(libdir, f))
             except OSError, err:
-                self.log.error("Something went wrong during symlink creation: %s" % err)
+                raise EasyBuildError("Something went wrong during symlink creation: %s", err)
 
         else:
             super(EB_METIS, self).install_step()

--- a/easybuild/easyblocks/m/modeller.py
+++ b/easybuild/easyblocks/m/modeller.py
@@ -31,6 +31,7 @@ import os
 
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd_qa
 
 
@@ -49,7 +50,7 @@ class EB_Modeller(EasyBlock):
         """Interactive install of Modeller."""
     
         if self.cfg['key'] is None: 
-            self.log.error("Easyconfig parameter 'key' is not defined")
+            raise EasyBuildError("Easyconfig parameter 'key' is not defined")
 
         cmd = "%s/Install" % self.cfg['start_dir']
 
@@ -84,13 +85,13 @@ class EB_Modeller(EasyBlock):
         if len(libdirs) == 1:
             libdir = libdirs[0]
         else:
-            self.log.error("Failed to isolate a single libdir from list of 'lib' subdirectories: %s" % libdirs)
+            raise EasyBuildError("Failed to isolate a single libdir from list of 'lib' subdirectories: %s", libdirs)
 
         py2libdirs = [d for d in os.listdir(os.path.join(self.installdir, 'lib', libdir)) if d.startswith('python2')]
         if len(py2libdirs) >= 1:
             py2libdir = py2libdirs[-1]
         else:
-            self.log.error("Failed to isolate latest Python lib dir from list %s" % py2libdirs)
+            raise EasyBuildError("Failed to isolate latest Python lib dir from list %s", py2libdirs)
 
         guesses.update({
             'PYTHONPATH': [os.path.join('lib', libdir, py2libdir), "modlib"],

--- a/easybuild/easyblocks/m/mothur.py
+++ b/easybuild/easyblocks/m/mothur.py
@@ -32,6 +32,7 @@ import os
 import shutil
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 
 
@@ -46,7 +47,7 @@ class EB_Mothur(ConfigureMake):
         if len(mothur_dirs) == 1:
             self.cfg['start_dir'] = mothur_dirs[0]
         else:
-            self.log.error("Failed to guess start directory in %s" % mothur_dirs)
+            raise EasyBuildError("Failed to guess start directory in %s", mothur_dirs)
 
         super(EB_Mothur, self).guess_start_dir()
 
@@ -81,7 +82,7 @@ class EB_Mothur(ConfigureMake):
                 srcfile = os.path.join(srcdir, filename)
                 shutil.copy2(srcfile, destdir)
         except OSError, err:
-            self.log.error("Copying %s to installation dir %s failed: %s", srcfile, destdir, err)
+            raise EasyBuildError("Copying %s to installation dir %s failed: %s", srcfile, destdir, err)
 
     def sanity_check_step(self):
         """Custom sanity check for Mothur."""

--- a/easybuild/easyblocks/m/mrbayes.py
+++ b/easybuild/easyblocks/m/mrbayes.py
@@ -38,6 +38,7 @@ import shutil
 from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
 
@@ -58,7 +59,7 @@ class EB_MrBayes(ConfigureMake):
             try:
                 os.chdir(self.cfg['start_dir'])
             except OSError, err:
-                self.log.error("Failed to change to correct source dir %s: %s" % (self.cfg['start_dir'], err))
+                raise EasyBuildError("Failed to change to correct source dir %s: %s", self.cfg['start_dir'], err)
 
             # run autoconf to generate configure script
             cmd = "autoconf"
@@ -71,7 +72,7 @@ class EB_MrBayes(ConfigureMake):
             else:
                 if get_software_root('BEAGLE'):
                     self.log.nosupport('BEAGLE module as dependency, should be beagle-lib', '2.0')
-                self.log.error("beagle-lib module not loaded?")
+                raise EasyBuildError("beagle-lib module not loaded?")
 
             if self.toolchain.options.get('usempi', None):
                 self.cfg.update('configopts', '--enable-mpi')
@@ -96,7 +97,7 @@ class EB_MrBayes(ConfigureMake):
                 shutil.copy2(src, dst)
                 self.log.info("Successfully copied %s to %s" % (src, dst))
             except (IOError,OSError), err:
-                self.log.error("Failed to copy %s to %s (%s)" % (src, dst, err))
+                raise EasyBuildError("Failed to copy %s to %s (%s)", src, dst, err)
 
     def sanity_check_step(self):
         """Custom sanity check for MrBayes."""

--- a/easybuild/easyblocks/m/mummer.py
+++ b/easybuild/easyblocks/m/mummer.py
@@ -39,6 +39,7 @@ import sys
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.easyblocks.perl import get_major_perl_version
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
 
 
@@ -94,7 +95,7 @@ class EB_MUMmer(ConfigureMake):
                     shutil.copy2(srcfile, destdir)
 
             except OSError, err:
-                self.log.error("Copying %s to installation dir %s failed: %s" % (srcfile, destdir, err))
+                raise EasyBuildError("Copying %s to installation dir %s failed: %s", srcfile, destdir, err)
 
     def make_module_extra(self):
         """Correctly prepend $PATH and $PERLXLIB for MUMmer."""

--- a/easybuild/easyblocks/m/mumps.py
+++ b/easybuild/easyblocks/m/mumps.py
@@ -38,6 +38,7 @@ import shutil
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools import toolchain
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 
 
@@ -64,7 +65,7 @@ class EB_MUMPS(ConfigureMake):
             optf = "-DALLOW_NON_INIT"
             optl = ""
         else:
-            self.log.error("Unknown compiler family, don't know to prepare for building with specified toolchain.")
+            raise EasyBuildError("Unknown compiler family, don't know to prepare for building with specified toolchain.")
 
         # copy selected Makefile.inc template
         try:
@@ -73,12 +74,12 @@ class EB_MUMPS(ConfigureMake):
             shutil.copy2(src, dst)
             self.log.debug("Successfully copied Makefile.inc to builddir.")
         except OSError, err:
-            self.log.error("Copying Makefile.inc to builddir failed.:%s" % err)
+            raise EasyBuildError("Copying Makefile.inc to builddir failed: %s", err)
 
         # check whether dependencies are available, and prepare
         scotch = get_software_root('SCOTCH')
         if not scotch:
-            self.log.error("SCOTCH dependency not available.")
+            raise EasyBuildError("SCOTCH dependency not available.")
 
         metis = get_software_root('METIS')
         parmetis = get_software_root('ParMETIS')
@@ -91,7 +92,7 @@ class EB_MUMPS(ConfigureMake):
             lmetis= "-L$EBROOTMETIS -lmetis"
             dmetis = "-Dmetis"
         else:
-            self.log.error("METIS or ParMETIS must be available as dependency.")
+            raise EasyBuildError("METIS or ParMETIS must be available as dependency.")
 
         # set Make options
         mumps_make_opts = {
@@ -127,7 +128,7 @@ class EB_MUMPS(ConfigureMake):
                 dst = os.path.join(self.installdir, path)
                 shutil.copytree(src, dst)
         except OSError, err:
-            self.log.error("Copying %s to installation dir %s failed: %s" % (src, dst, err))
+            raise EasyBuildError("Copying %s to installation dir %s failed: %s", src, dst, err)
 
     def sanity_check_step(self):
         """Custom sanity check for MUMPS."""

--- a/easybuild/easyblocks/m/mvapich2.py
+++ b/easybuild/easyblocks/m/mvapich2.py
@@ -37,6 +37,7 @@ import os
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 
 
 class EB_MVAPICH2(ConfigureMake):
@@ -97,12 +98,8 @@ class EB_MVAPICH2(ConfigureMake):
                     env.setvar(new_envvar, envvar_val)
                     env.setvar(envvar, '')
                 else:
-                    self.log.error("Both %(ev)s and %(nev)s set, can I overwrite %(nev)s with %(ev)s (%(evv)s) ?" %
-                                     {
-                                      'ev': envvar,
-                                      'nev': new_envvar,
-                                      'evv': envvar_val
-                                     })
+                    raise EasyBuildError("Both $%s and $%s set, can I overwrite $%s with $%s (%s) ?",
+                                         envvar, new_envvar, new_envvar, envvar, envvar_val)
 
         # enable specific support options (if desired)
         if self.cfg['withmpe']:

--- a/easybuild/easyblocks/n/namd.py
+++ b/easybuild/easyblocks/n/namd.py
@@ -22,6 +22,7 @@ from distutils.version import LooseVersion
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.makecp import MakeCp
 from easybuild.framework.easyconfig import CUSTOM, MANDATORY
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import extract_file
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
@@ -71,7 +72,7 @@ class EB_NAMD(MakeCp):
         }
         namd_comp = namd_comps.get(comp_fam, None)
         if charm_arch_comp is None or namd_comp is None:
-            self.log.error("Unknown compiler family, can't complete Charm++/NAMD target architecture.")
+            raise EasyBuildError("Unknown compiler family, can't complete Charm++/NAMD target architecture.")
         self.cfg.update('charm_arch', charm_arch_comp)
 
         self.log.info("Updated 'charm_arch': %s" % self.cfg['charm_arch'])
@@ -80,7 +81,7 @@ class EB_NAMD(MakeCp):
 
         charm_tarballs = glob.glob('charm-*.tar')
         if len(charm_tarballs) != 1:
-            self.log.error("Expected to find exactly one tarball for Charm++, found: %s" % charm_tarballs)
+            raise EasyBuildError("Expected to find exactly one tarball for Charm++, found: %s", charm_tarballs)
 
         extract_file(charm_tarballs[0], os.getcwd())
 
@@ -105,7 +106,7 @@ class EB_NAMD(MakeCp):
                 if LooseVersion(self.version) >= LooseVersion('2.9'):
                     self.cfg.update('namd_cfg_opts', "--with-fftw3")
                 else:
-                    self.log.error("Using FFTW v3.x only supported in NAMD v2.9 and up.")
+                    raise EasyBuildError("Using FFTW v3.x only supported in NAMD v2.9 and up.")
             else:
                 self.cfg.update('namd_cfg_opts', "--with-fftw")
             self.cfg.update('namd_cfg_opts', "--fftw-prefix %s" % fftw)
@@ -134,7 +135,8 @@ class EB_NAMD(MakeCp):
                 if test_ok_regex.search(out):
                     self.log.debug("Test '%s' ran fine." % cmd)
                 else:
-                    self.log.error("Test '%s' failed ('%s' not found), output: %s" % (cmd, test_ok_regex.pattern, out))
+                    raise EasyBuildError("Test '%s' failed ('%s' not found), output: %s",
+                                         cmd, test_ok_regex.pattern, out)
         else:
             self.log.debug("Skipping running NAMD test case after building")
 
@@ -150,7 +152,7 @@ class EB_NAMD(MakeCp):
                 elif os.path.isfile(fullsrc):
                     shutil.copy2(fullsrc, self.installdir)
         except OSError, err:
-            self.log.error("Failed to copy NAMD build from %s to install directory: %s" % (srcdir, err))
+            raise EasyBuildError("Failed to copy NAMD build from %s to install directory: %s", srcdir, err)
 
     def make_module_extra(self):
         """Add the install directory to PATH"""

--- a/easybuild/easyblocks/n/ncl.py
+++ b/easybuild/easyblocks/n/ncl.py
@@ -39,6 +39,7 @@ import sys
 from distutils.version import LooseVersion
 
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
 
@@ -58,7 +59,7 @@ class EB_NCL(EasyBlock):
         try:
             os.chdir('config')
         except OSError, err:
-            self.log.error("Failed to change to the 'config' dir: %s" % err)
+            raise EasyBuildError("Failed to change to the 'config' dir: %s", err)
 
         cmd = "make -f Makefile.ini"
         run_cmd(cmd, log_all=True, simple=True)
@@ -118,7 +119,7 @@ class EB_NCL(EasyBlock):
         try:
             os.chdir(self.cfg['start_dir'])
         except OSError, err:
-            self.log.error("Failed to change to the build dir %s: %s" % (self.cfg['start_dir'], err))
+            raise EasyBuildError("Failed to change to the build dir %s: %s", self.cfg['start_dir'], err)
 
         # instead of running the Configure script that asks a zillion questions,
         # let's just generate the config/Site.local file ourselves...
@@ -132,7 +133,7 @@ class EB_NCL(EasyBlock):
         for dep in deps:
             root = get_software_root(dep)
             if not root:
-                self.log.error('%s not available' % dep)
+                raise EasyBuildError("%s not available", dep)
             libs += ' -L%s/lib ' % root
             includes += ' -I%s/include ' % root
 

--- a/easybuild/easyblocks/n/netcdf.py
+++ b/easybuild/easyblocks/n/netcdf.py
@@ -39,6 +39,7 @@ import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root, get_software_version
 
 
@@ -100,7 +101,7 @@ def set_netcdf_env_vars(log):
 
     netcdf = get_software_root('netCDF')
     if not netcdf:
-        log.error("netCDF module not loaded?")
+        raise EasyBuildError("netCDF module not loaded?")
     else:
         env.setvar('NETCDF', netcdf)
         log.debug("Set NETCDF to %s" % netcdf)
@@ -108,7 +109,7 @@ def set_netcdf_env_vars(log):
         netcdf_ver = get_software_version('netCDF')
         if not netcdff:
             if LooseVersion(netcdf_ver) >= LooseVersion("4.2"):
-                log.error("netCDF v4.2 no longer supplies Fortran library, also need netCDF-Fortran")
+                raise EasyBuildError("netCDF v4.2 no longer supplies Fortran library, also need netCDF-Fortran")
         else:
             env.setvar('NETCDFF', netcdff)
             log.debug("Set NETCDFF to %s" % netcdff)
@@ -125,4 +126,4 @@ def get_netcdf_module_set_cmds(log):
             txt += "setenv NETCDFF %s\n" % netcdff
         return txt
     else:
-        log.error("NETCDF environment variable not set?")
+        raise EasyBuildError("NETCDF environment variable not set?")

--- a/easybuild/easyblocks/n/neuron.py
+++ b/easybuild/easyblocks/n/neuron.py
@@ -33,6 +33,7 @@ import re
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.easyblocks.generic.pythonpackage import det_pylibdir
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import adjust_permissions
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
@@ -102,7 +103,7 @@ class EB_NEURON(ConfigureMake):
                 pwd = os.getcwd()
                 os.chdir(pypath)
             except OSError, err:
-                self.log.error("Failed to change to %s: %s" % (pypath, err))
+                raise EasyBuildError("Failed to change to %s: %s", pypath, err)
 
             cmd = "python setup.py install --prefix=%s" % self.installdir
             run_cmd(cmd, simple=True, log_all=True, log_ok=True)
@@ -110,7 +111,7 @@ class EB_NEURON(ConfigureMake):
             try:
                 os.chdir(pwd)
             except OSError, err:
-                self.log.error("Failed to change back to %s: %s" % (pwd, err))
+                raise EasyBuildError("Failed to change back to %s: %s", pwd, err)
 
 
     def sanity_check_step(self):
@@ -161,7 +162,7 @@ class EB_NEURON(ConfigureMake):
 
         validate_regexp = re.compile("^\s+-65\s*\n\s+5\s*\n\s+-68.134337", re.M)
         if ec or not validate_regexp.search(out):
-            self.log.error("Validation of NEURON demo run failed.")
+            raise EasyBuildError("Validation of NEURON demo run failed.")
         else:
             self.log.info("Validation of NEURON demo OK!")
 
@@ -176,7 +177,7 @@ class EB_NEURON(ConfigureMake):
 
             os.chdir(cwd)
         except OSError, err:
-            self.log.error("Failed to run parallel hello world: %s" % err)
+            raise EasyBuildError("Failed to run parallel hello world: %s", err)
 
         valid = True
         for i in range(0, nproc):
@@ -185,7 +186,7 @@ class EB_NEURON(ConfigureMake):
                 valid = False
                 break
         if ec or not valid:
-            self.log.error("Validation of parallel hello world run failed.")
+            raise EasyBuildError("Validation of parallel hello world run failed.")
         else:
             self.log.info("Parallel hello world OK!")
 

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -38,6 +38,7 @@ import tempfile
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.fortranpythonpackage import FortranPythonPackage
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import rmtree2
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
@@ -134,8 +135,8 @@ class EB_numpy(FortranPythonPackage):
                     patch_found = True
                     break
             if not patch_found:
-                self.log.error("Building numpy on top of Intel MKL requires a patch to "
-                               "handle -Wl linker flags correctly, which doesn't seem to be there.")
+                raise EasyBuildError("Building numpy on top of Intel MKL requires a patch to "
+                                     "handle -Wl linker flags correctly, which doesn't seem to be there.")
 
         else:
             # unless Intel MKL is used, $ATLAS should be set to take full control,
@@ -159,7 +160,8 @@ class EB_numpy(FortranPythonPackage):
                 if not cblaslib in libs:
                     libs = ':'.join([libs, cblaslib])
             else:
-                self.log.error("CBLAS is required next to ACML to provide a C interface to BLAS, but it's not loaded.")
+                raise EasyBuildError("CBLAS is required next to ACML to provide a C interface to BLAS, "
+                                     "but it's not loaded.")
 
         if fft:
             extrasiteconfig += "\n[fftw]\nlibraries = %s" % fft
@@ -192,7 +194,7 @@ class EB_numpy(FortranPythonPackage):
             pwd = os.getcwd()
             os.chdir(tmpdir)
         except OSError, err:
-            self.log.error("Faild to change to %s: %s" % (tmpdir, err))
+            raise EasyBuildError("Faild to change to %s: %s", tmpdir, err)
 
         # evaluate performance of numpy.dot (3 runs, 3 loops each)
         size = 1000
@@ -218,21 +220,20 @@ class EB_numpy(FortranPythonPackage):
             if res:
                 time_msec = 1000 * float(res.group('time'))
             else:
-                self.log.error("Failed to determine time for numpy.dot test run.")
+                raise EasyBuildError("Failed to determine time for numpy.dot test run.")
 
         # make sure we observe decent performance
         if time_msec < max_time_msec:
-            self.log.info("Time for %(size)dx%(size)d matrix dot product: %(time)d msec < %(maxtime)d msec => OK" %
-                {'size': size, 'time': time_msec, 'maxtime': max_time_msec})
+            self.log.info("Time for %dx%d matrix dot product: %d msec < %d msec => OK",
+                          size, size, time_msec, max_time_msec)
         else:
-            self.log.error("Time for %(size)dx%(size)d matrix dot product: %(time)d msec >= %(maxtime)d msec => ERROR" %
-                {'size': size, 'time': time_msec, 'maxtime': max_time_msec})
-
+            raise EasyBuildError("Time for %dx%d matrix dot product: %d msec >= %d msec => ERROR",
+                                 size, size, time_msec, max_time_msec)
         try:
             os.chdir(pwd)
             rmtree2(tmpdir)
         except OSError, err:
-            self.log.error("Failed to change back to %s: %s" % (pwd, err))
+            raise EasyBuildError("Failed to change back to %s: %s", pwd, err)
 
     def sanity_check_step(self, *args, **kwargs):
         """Custom sanity check for numpy."""

--- a/easybuild/easyblocks/n/nwchem.py
+++ b/easybuild/easyblocks/n/nwchem.py
@@ -39,6 +39,7 @@ import easybuild.tools.toolchain as toolchain
 from distutils.version import LooseVersion
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import adjust_permissions, mkdir
 from easybuild.tools.modules import get_software_libdir, get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
@@ -98,15 +99,16 @@ class EB_NWChem(ConfigureMake):
                     f = open(self.local_nwchemrc, 'w')
                     f.write('dummy')
                     f.close()
-                self.log.debug("Contents of %s: %s" % (os.path.dirname(self.local_nwchemrc), os.listdir(os.path.dirname(self.local_nwchemrc))))
+                self.log.debug("Contents of %s: %s", os.path.dirname(self.local_nwchemrc),
+                               os.listdir(os.path.dirname(self.local_nwchemrc)))
                 if os.path.exists(self.home_nwchemrc) and not os.path.samefile(self.home_nwchemrc, self.local_nwchemrc):
-                    msg = "Found %s, but it's not a symlink to %s" % (self.home_nwchemrc, self.local_nwchemrc)
-                    msg += "\nPlease (re)move %s while installing NWChem; it can be restored later" % self.home_nwchemrc
-                    self.log.error(msg)
+                    raise EasyBuildError("Found %s, but it's not a symlink to %s. "
+                                         "Please (re)move %s while installing NWChem; it can be restored later",
+                                         self.home_nwchemrc, self.local_nwchemrc, self.home_nwchemrc)
                 # ok to remove, we'll recreate it anyway
                 os.remove(self.local_nwchemrc)
         except (IOError, OSError), err:
-            self.log.error("Failed to validate %s symlink: %s" % (self.home_nwchemrc, err))
+            raise EasyBuildError("Failed to validate %s symlink: %s", self.home_nwchemrc, err)
 
         # building NWChem in a long path name is an issue, so let's make sure we have a short one
         try:
@@ -117,13 +119,13 @@ class EB_NWChem(ConfigureMake):
             os.chdir(tmpdir)
             self.cfg['start_dir'] = tmpdir
         except OSError, err:
-            self.log.error("Failed to symlink build dir to a shorter path name: %s" % err)
+            raise EasyBuildError("Failed to symlink build dir to a shorter path name: %s", err)
 
         # change to actual build dir
         try:
             os.chdir('src')
         except OSError, err:
-            self.log.error("Failed to change to build dir: %s" % err)
+            raise EasyBuildError("Failed to change to build dir: %s", err)
 
         nwchem_modules = self.cfg['modules']
 
@@ -140,7 +142,7 @@ class EB_NWChem(ConfigureMake):
         if 'python' in self.cfg['modules']:
             python_root = get_software_root('Python')
             if not python_root:
-                self.log.error("Python module not loaded, you should add Python as a dependency.")
+                raise EasyBuildError("Python module not loaded, you should add Python as a dependency.")
             env.setvar('PYTHONHOME', python_root)
             pyver = '.'.join(get_software_version('Python').split('.')[0:2])
             env.setvar('PYTHONVERSION', pyver)
@@ -151,7 +153,7 @@ class EB_NWChem(ConfigureMake):
                 libreadline_libdir = os.path.join(libreadline, get_software_libdir('libreadline'))
                 ncurses = get_software_root('ncurses')
                 if not ncurses:
-                    self.log.error("ncurses is not loaded, but required to link with libreadline")
+                    raise EasyBuildError("ncurses is not loaded, but required to link with libreadline")
                 ncurses_libdir = os.path.join(ncurses, get_software_libdir('ncurses'))
                 readline_libs = ' '.join([
                     os.path.join(libreadline_libdir, 'libreadline.a'),
@@ -186,7 +188,7 @@ class EB_NWChem(ConfigureMake):
         elif mpi_family in [toolchain.MPICH, toolchain.MPICH2]:
             libmpi = "-lmpichf90 -lmpich -lopa -lmpl -lrt -lpthread"
         else:
-            self.log.error("Don't know how to set LIBMPI for %s" % mpi_family)
+            raise EasyBuildError("Don't know how to set LIBMPI for %s", mpi_family)
         env.setvar('LIBMPI', libmpi)
 
         # compiler optimization flags: set environment variables _and_ add them to list of make options
@@ -262,7 +264,7 @@ class EB_NWChem(ConfigureMake):
             os.chdir(cwd)
 
         except OSError, err:
-            self.log.error("Failed to build version info: %s" % err)
+            raise EasyBuildError("Failed to build version info: %s", err)
 
         # run getmem.nwchem script to assess memory availability and make an educated guess
         # this is an alternative to specifying -DDFLT_TOT_MEM via LIB_DEFINES
@@ -273,7 +275,7 @@ class EB_NWChem(ConfigureMake):
                 run_cmd("./getmem.nwchem", simple=True, log_all=True, log_ok=True, log_output=True)
                 os.chdir(self.cfg['start_dir'])
             except OSError, err:
-                self.log.error("Failed to run getmem.nwchem script: %s" % err)
+                raise EasyBuildError("Failed to run getmem.nwchem script: %s", err)
 
     def install_step(self):
         """Custom install procedure for NWChem."""
@@ -294,7 +296,7 @@ class EB_NWChem(ConfigureMake):
                             os.path.join(self.installdir, 'data', 'libraryps'))
 
         except OSError, err:
-            self.log.error("Failed to install NWChem: %s" % err)
+            raise EasyBuildError("Failed to install NWChem: %s", err)
 
         # create NWChem settings file
         fn = os.path.join(self.installdir, 'data', 'default.nwchemrc')
@@ -316,7 +318,7 @@ class EB_NWChem(ConfigureMake):
             f.write(txt)
             f.close()
         except IOError, err:
-            self.log.error("Failed to create %s: %s" % (fn, err))
+            raise EasyBuildError("Failed to create %s: %s", fn, err)
 
         # fix permissions in data directory
         datadir = os.path.join(self.installdir, 'data')
@@ -362,7 +364,7 @@ class EB_NWChem(ConfigureMake):
             self.log.info("Copied %s to %s." % (exs_dir, self.examples_dir))
 
         except OSError, err:
-            self.log.error("Failed to copy examples: %s" % err)
+            raise EasyBuildError("Failed to copy examples: %s", err)
 
         super(EB_NWChem, self).cleanup_step()
 
@@ -410,7 +412,7 @@ class EB_NWChem(ConfigureMake):
                 if not os.path.exists(self.home_nwchemrc):
                     os.symlink(self.local_nwchemrc, self.home_nwchemrc)
             except OSError, err:
-                self.log.error("Failed to symlink %s to %s: %s" % (self.home_nwchemrc, self.local_nwchemrc, err))
+                raise EasyBuildError("Failed to symlink %s to %s: %s", self.home_nwchemrc, self.local_nwchemrc, err)
 
             # run tests, keep track of fail ratio
             cwd = os.getcwd()
@@ -481,17 +483,17 @@ class EB_NWChem(ConfigureMake):
 
             if fail_ratio > self.cfg['max_fail_ratio']:
                 max_fail_pcnt = self.cfg['max_fail_ratio'] * 100
-                self.log.error("Over %s%% of test cases failed, assuming broken build." % max_fail_pcnt)
+                raise EasyBuildError("Over %s%% of test cases failed, assuming broken build.", max_fail_pcnt)
 
             # cleanup
             try:
                 shutil.rmtree(self.examples_dir)
                 shutil.rmtree(local_nwchemrc_dir)
             except OSError, err:
-                self.log.error("Cleanup failed: %s" % err)
+                raise EasyBuildError("Cleanup failed: %s", err)
 
             # set post msg w.r.t. cleaning up $HOME/.nwchemrc symlink
             self.postmsg += "\nRemember to clean up %s after all NWChem builds are finished." % self.home_nwchemrc
 
         except OSError, err:
-            self.log.error("Failed to run test cases: %s" % err)
+            raise EasyBuildError("Failed to run test cases: %s", err)

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -40,6 +40,7 @@ from distutils.version import LooseVersion
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import adjust_permissions, mkdir
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd, run_cmd_qa
@@ -88,7 +89,7 @@ class EB_OpenFOAM(EasyBlock):
                         shutil.move(source, target)
                 os.chdir(openfoam_installdir)
             except OSError, err:
-                self.log.error("Failed to move all files to %s: %s" % (openfoam_installdir, err))
+                raise EasyBuildError("Failed to move all files to %s: %s", openfoam_installdir, err)
 
     def configure_step(self):
         """Configure OpenFOAM build by setting appropriate environment variables."""
@@ -119,7 +120,7 @@ class EB_OpenFOAM(EasyBlock):
             self.cfg.update('prebuildopts', 'CFLAGS="$CFLAGS -no-prec-div" CXXFLAGS="$CXXFLAGS -no-prec-div"')
 
         else:
-            self.log.error("Unknown compiler family, don't know how to set WM_COMPILER")
+            raise EasyBuildError("Unknown compiler family, don't know how to set WM_COMPILER")
 
         env.setvar("WM_COMPILER", self.wm_compiler)
 

--- a/easybuild/easyblocks/o/openifs.py
+++ b/easybuild/easyblocks/o/openifs.py
@@ -33,6 +33,7 @@ import shutil
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
 
@@ -44,7 +45,7 @@ class EB_OpenIFS(EasyBlock):
         """Custom configuration procedure for OpenIFS."""
         # make sure use of MPI is enabled
         if not self.toolchain.options.get('usempi', None):
-            self.log.error("Use of MPI should be enabled, set 'usempi' toolchain option to 'True'.")
+            raise EasyBuildError("Use of MPI should be enabled, set 'usempi' toolchain option to 'True'.")
 
         # configure build via OIFS_* environment variables
         env.setvar('OIFS_ARCH', 'x86_64')
@@ -54,7 +55,7 @@ class EB_OpenIFS(EasyBlock):
         elif self.toolchain.comp_family() == toolchain.INTELCOMP: 
             env.setvar('OIFS_COMP', 'intel')
         else:
-            self.log.error("Unknown compiler used, don't know how to set $OIFS_COMP.")
+            raise EasyBuildError("Unknown compiler used, don't know how to set $OIFS_COMP.")
 
         # give EasyBuild control over compiler options
         env.setvar('OIFS_CC', os.getenv('CC'))
@@ -67,7 +68,7 @@ class EB_OpenIFS(EasyBlock):
         if grib_api_root:
             env.setvar('OIFS_GRIB_API_DIR', grib_api_root)
         else:
-            self.log.error("grib_api module not loaded")
+            raise EasyBuildError("grib_api module not loaded")
 
         env.setvar('OIFS_LAPACK_LIB', "-L%s %s" % (os.getenv('LAPACK_LIB_DIR'), os.getenv('LIBLAPACK')))
 
@@ -76,7 +77,7 @@ class EB_OpenIFS(EasyBlock):
         try:
             os.chdir('make')
         except OSError, err:
-            self.log.error("Failed to move to 'make' dir: %s" % err)
+            raise EasyBuildError("Failed to move to 'make' dir: %s", err)
 
         # enable parallel build
         par = self.cfg['parallel']
@@ -92,7 +93,7 @@ class EB_OpenIFS(EasyBlock):
             shutil.copy2(os.path.join(srcdir, 'bin', 'master.exe'), bindir)
             shutil.copytree(os.path.join(srcdir, 'include'), os.path.join(self.installdir, 'include'))
         except OSError, err:
-            self.log.error("Failed to install OpenIFS: %s" % err)
+            raise EasyBuildError("Failed to install OpenIFS: %s", err)
 
     def sanity_check_step(self):
         """Custom sanity check for OpenIFS."""

--- a/easybuild/easyblocks/o/openssl.py
+++ b/easybuild/easyblocks/o/openssl.py
@@ -31,6 +31,7 @@ EasyBuild support for OpenSSL, implemented as an easyblock
 import os
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
 
 
@@ -57,7 +58,7 @@ class EB_OpenSSL(ConfigureMake):
             if os.path.exists(os.path.join(self.installdir, libdir_cand)):
                 libdir = libdir_cand
         if libdir is None:
-            self.log.error("Failed to determine library directory.")
+            raise EasyBuildError("Failed to determine library directory.")
 
         custom_paths = {
             'files': [os.path.join(libdir, x) for x in ['engines', 'libcrypto.a', 'libcrypto.so',

--- a/easybuild/easyblocks/p/parmetis.py
+++ b/easybuild/easyblocks/p/parmetis.py
@@ -36,6 +36,7 @@ import shutil
 from distutils.version import LooseVersion
 
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import mkdir
 from easybuild.tools.run import run_cmd
 
@@ -73,7 +74,7 @@ class EB_ParMETIS(EasyBlock):
                 run_cmd(cmd, log_all=True, simple=True)
                 os.chdir(self.cfg['start_dir'])
             except OSError, err:
-                self.log.error("Running cmake in %s failed: %s" % (self.parmetis_builddir, err))
+                raise EasyBuildError("Running cmake in %s failed: %s", self.parmetis_builddir, err)
 
     def build_step(self, verbose=False):
         """Build ParMETIS (and METIS) using build_step."""
@@ -99,7 +100,7 @@ class EB_ParMETIS(EasyBlock):
                 run_cmd(cmd, log_all=True, simple=True, log_output=verbose)
                 os.chdir(self.cfg['start_dir'])
             except OSError, err:
-                self.log.error("Running cmd '%s' in %s failed: %s" % (cmd, self.parmetis_builddir, err))
+                raise EasyBuildError("Running cmd '%s' in %s failed: %s", cmd, self.parmetis_builddir, err)
         else:
             run_cmd(cmd, log_all=True, simple=True, log_output=verbose)
 
@@ -120,7 +121,7 @@ class EB_ParMETIS(EasyBlock):
                 run_cmd(cmd, log_all=True, simple=True)
                 os.chdir(self.cfg['start_dir'])
             except OSError, err:
-                self.log.error("Running '%s' in %s failed: %s" % (cmd, self.parmetis_builddir, err))
+                raise EasyBuildError("Running '%s' in %s failed: %s", cmd, self.parmetis_builddir, err)
 
             # libraries
             try:
@@ -128,7 +129,7 @@ class EB_ParMETIS(EasyBlock):
                 dst = os.path.join(libdir, 'libmetis.a')
                 shutil.copy2(src, dst)
             except OSError, err:
-                self.log.error("Copying files to installation dir failed: %s" % err)
+                raise EasyBuildError("Copying files to installation dir failed: %s", err)
 
             # include files
             try:
@@ -136,7 +137,7 @@ class EB_ParMETIS(EasyBlock):
                 dst = os.path.join(includedir, 'metis.h')
                 shutil.copy2(src, dst)
             except OSError, err:
-                self.log.error("Copying files to installation dir failed: %s" % err)
+                raise EasyBuildError("Copying files to installation dir failed: %s", err)
 
         else:
             mkdir(libdir)
@@ -149,7 +150,7 @@ class EB_ParMETIS(EasyBlock):
                     dst = os.path.join(libdir, fil)
                     shutil.copy2(src, dst)
             except OSError, err:
-                self.log.error("Copying files to installation dir failed: %s" % err)
+                raise EasyBuildError("Copying files to installation dir failed: %s", err)
 
             # include files
             try:
@@ -160,7 +161,7 @@ class EB_ParMETIS(EasyBlock):
                 dst = os.path.join(includedir, 'metis.h')
                 shutil.copy2(src, dst)
             except OSError, err:
-                self.log.error("Copying files to installation dir failed: %s" % err)
+                raise EasyBuildError("Copying files to installation dir failed: %s", err)
 
         # other applications depending on ParMETIS (SuiteSparse for one) look for both ParMETIS libraries
         # and header files in the Lib directory (capital L). The following symlink are hence created.
@@ -170,7 +171,7 @@ class EB_ParMETIS(EasyBlock):
             for f in ['metis.h', 'parmetis.h']:
                 os.symlink(os.path.join(includedir, f), os.path.join(libdir, f))
         except OSError, err:
-            self.log.error("Something went wrong during symlink creation: %s" % err)
+            raise EasyBuildError("Something went wrong during symlink creation: %s", err)
 
     def sanity_check_step(self):
         """Custom sanity check for ParMETIS."""

--- a/easybuild/easyblocks/p/pasha.py
+++ b/easybuild/easyblocks/p/pasha.py
@@ -32,6 +32,7 @@ import shutil
 import os
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 
 
@@ -43,7 +44,7 @@ class EB_Pasha(ConfigureMake):
 
         tbb = get_software_root('TBB')
         if not tbb:
-            self.log.error("TBB module not loaded.")
+            raise EasyBuildError("TBB module not loaded.")
 
         self.cfg.update('buildopts', "TBB_DIR=%s/tbb MPI_DIR='' MPI_INC='' " % tbb)
         self.cfg.update('buildopts', 'MPI_CXX="%s" OPM_FLAG="%s"' % (os.getenv('MPICXX'), self.toolchain.get_flag('openmp')))

--- a/easybuild/easyblocks/p/petsc.py
+++ b/easybuild/easyblocks/p/petsc.py
@@ -35,6 +35,7 @@ import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import BUILD, CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
@@ -118,9 +119,8 @@ class EB_PETSc(ConfigureMake):
                     self.cfg.update('configopts', '--with-papi-include=%s' % papi_inc)
                     self.cfg.update('configopts', '--with-papi-lib=%s' % papi_lib)
                 else:
-                    self.log.error("PAPI header (%s) and/or lib (%s) not found, " % (papi_inc_file,
-                                                                                     papi_lib) + \
-                                   "can not enable PAPI support?")
+                    raise EasyBuildError("PAPI header (%s) and/or lib (%s) not found, can not enable PAPI support?",
+                                         papi_inc_file, papi_lib)
 
             # Python extensions_step
             if get_software_root('Python'):
@@ -150,7 +150,7 @@ class EB_PETSc(ConfigureMake):
             if bl_libdir and bl_libs:
                 self.cfg.update('configopts', '--with-blas-lapack-lib=[%s/%s]' % (bl_libdir, bl_libs))
             else:
-                self.log.error("One or more environment variables for BLAS/LAPACK not defined?")
+                raise EasyBuildError("One or more environment variables for BLAS/LAPACK not defined?")
 
             # additional dependencies
             # filter out deps handled seperately
@@ -211,7 +211,7 @@ class EB_PETSc(ConfigureMake):
             # check for errors in configure
             error_regexp = re.compile("ERROR")
             if error_regexp.search(out):
-                self.log.error("Error(s) detected in configure output!")
+                raise EasyBuildError("Error(s) detected in configure output!")
 
             if self.cfg['sourceinstall']:
                 # figure out PETSC_ARCH setting
@@ -221,7 +221,7 @@ class EB_PETSc(ConfigureMake):
                     self.petsc_arch = res.group(1)
                     self.cfg.update('buildopts', 'PETSC_ARCH=%s' % self.petsc_arch)
                 else:
-                    self.log.error("Failed to determine PETSC_ARCH setting.")
+                    raise EasyBuildError("Failed to determine PETSC_ARCH setting.")
 
             self.petsc_subdir = '%s-%s' % (self.name.lower(), self.version)
 
@@ -262,7 +262,7 @@ class EB_PETSc(ConfigureMake):
                     bmakedir = os.path.join(self.installdir, 'bmake', 'linux-gnu-c-opt')
                     os.symlink(os.path.join(bmakedir, f), os.path.join(includedir, f))
             except Exception, err:
-                self.log.error("Something went wrong during symlink creation of file %s: %s" % (f, err))
+                raise EasyBuildError("Something went wrong during symlink creation of file %s: %s", f, err)
 
     def make_module_req_guess(self):
         """Specify PETSc custom values for PATH, CPATH and LD_LIBRARY_PATH."""

--- a/easybuild/easyblocks/p/picard.py
+++ b/easybuild/easyblocks/p/picard.py
@@ -38,6 +38,7 @@ import shutil
 
 from distutils.version import LooseVersion
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.build_log import EasyBuildError
 
 
 class EB_picard(EasyBlock):
@@ -58,7 +59,7 @@ class EB_picard(EasyBlock):
         if not re.search("%s/?$" % picard_tools_dir, self.cfg['start_dir']):
             self.cfg['start_dir'] = os.path.join(self.cfg['start_dir'], picard_tools_dir)
             if not os.path.exists(self.cfg['start_dir']):
-                self.log.error("Path %s to copy files from doesn't exist." % self.cfg['start_dir'])
+                raise EasyBuildError("Path %s to copy files from doesn't exist.", self.cfg['start_dir'])
 
         for jar in os.listdir(self.cfg['start_dir']):
             src = os.path.join(self.cfg['start_dir'], jar)
@@ -67,7 +68,7 @@ class EB_picard(EasyBlock):
                 shutil.copy2(src, dst)
                 self.log.info("Successfully copied %s to %s" % (src, dst))
             except OSError, err:
-                self.log.error("Failed to copy %s to %s (%s)" % (src, dst, err))
+                raise EasyBuildError("Failed to copy %s to %s (%s)", src, dst, err)
 
     def sanity_check_step(self):
         """Custom sanity check for picard"""

--- a/easybuild/easyblocks/p/psi.py
+++ b/easybuild/easyblocks/p/psi.py
@@ -38,6 +38,7 @@ import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import BUILD
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 
 
@@ -73,7 +74,7 @@ class EB_PSI(CMakeMake):
             os.makedirs(objdir)
             os.chdir(objdir)
         except OSError, err:
-            self.log.error("Failed to prepare for configuration of PSI build: %s" % err)
+            raise EasyBuildError("Failed to prepare for configuration of PSI build: %s", err)
 
         env.setvar('F77FLAGS', os.getenv('F90FLAGS'))
 
@@ -88,12 +89,12 @@ class EB_PSI(CMakeMake):
         # explicitely specify Python binary to use
         pythonroot = get_software_root('Python')
         if not pythonroot:
-            self.log.error("Python module not loaded.")
+            raise EasyBuildError("Python module not loaded.")
 
         # Use EB Boost
         boostroot = get_software_root('Boost')
         if not boostroot:
-            self.log.error("Boost module not loaded.")
+            raise EasyBuildError("Boost module not loaded.")
 
         # pre 4.0b5, they were using autotools, on newer it's CMake
         if LooseVersion(self.version) <= LooseVersion("4.0b5"):
@@ -155,7 +156,7 @@ class EB_PSI(CMakeMake):
                 # copy symlinks as symlinks to work around broken symlinks
                 shutil.copytree(os.path.join(self.builddir, subdir), os.path.join(self.installdir, subdir), symlinks=True)
         except OSError, err:
-            self.log.error("Failed to copy obj and unpacked sources to install dir: %s" % err)
+            raise EasyBuildError("Failed to copy obj and unpacked sources to install dir: %s", err)
 
     def test_step(self):
         """
@@ -168,7 +169,7 @@ class EB_PSI(CMakeMake):
         try:
             shutil.rmtree(testdir)
         except OSError, err:
-            self.log.error("Failed to remove test directory %s: %s" % (testdir, err))
+            raise EasyBuildError("Failed to remove test directory %s: %s", testdir, err)
 
     def sanity_check_step(self):
         """Custom sanity check for PSI."""

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -109,7 +109,7 @@ class EB_Python(ConfigureMake):
             try:
                 os.symlink(srcbin, python_binary_path)
             except OSError, err:
-                raise EasyBuildError("Failed to symlink %s to %s: %s", err)
+                raise EasyBuildError("Failed to symlink %s to %s: %s", srcbin, python_binary_path, err)
 
     def sanity_check_step(self):
         """Custom sanity check for Python."""

--- a/easybuild/easyblocks/p/python.py
+++ b/easybuild/easyblocks/p/python.py
@@ -86,7 +86,7 @@ class EB_Python(ConfigureMake):
                     line = re.sub(r"^#readline readline.c.*", readline, line)
                     sys.stdout.write(line)
             else:
-                self.log.error("Both libreadline and ncurses are required to ensure readline support")
+                raise EasyBuildError("Both libreadline and ncurses are required to ensure readline support")
 
         openssl = get_software_root('OpenSSL')
         if openssl:
@@ -109,7 +109,7 @@ class EB_Python(ConfigureMake):
             try:
                 os.symlink(srcbin, python_binary_path)
             except OSError, err:
-                self.log.error("Failed to symlink %s to %s: %s" % err)
+                raise EasyBuildError("Failed to symlink %s to %s: %s", err)
 
     def sanity_check_step(self):
         """Custom sanity check for Python."""
@@ -119,7 +119,7 @@ class EB_Python(ConfigureMake):
         try:
             fake_mod_data = self.load_fake_module()
         except EasyBuildError, err:
-            self.log.error("Loading fake module failed: %s" % err)
+            raise EasyBuildError("Loading fake module failed: %s", err)
 
         abiflags = ''
         if LooseVersion(self.version) >= LooseVersion("3"):
@@ -127,7 +127,7 @@ class EB_Python(ConfigureMake):
             cmd = 'python -c "import sysconfig; print(sysconfig.get_config_var(\'abiflags\'));"'
             (abiflags, _) = run_cmd(cmd, log_all=True, simple=False)
             if not abiflags:
-                self.log.error("Failed to determine abiflags: %s" % abiflags)
+                raise EasyBuildError("Failed to determine abiflags: %s", abiflags)
             else:
                 abiflags = abiflags.strip()
 

--- a/easybuild/easyblocks/p/python_meep.py
+++ b/easybuild/easyblocks/p/python_meep.py
@@ -37,6 +37,7 @@ import shutil
 import tempfile
 
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import extract_file, rmtree2
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
@@ -54,7 +55,7 @@ class EB_python_minus_meep(PythonPackage):
         deps = ["Meep", "Python"]
         for dep in deps:
             if not get_software_root(dep):
-                self.log.error("Module for %s not loaded." % dep)
+                raise EasyBuildError("Module for %s not loaded.", dep)
 
     def build_step(self):
         """Build python-meep using available make/make-mpi script."""
@@ -88,9 +89,9 @@ class EB_python_minus_meep(PythonPackage):
                                   "%s-%s.*.tar.gz" % (self.name, shortver))
         matches = glob.glob(fn_pattern)
         if not matches:
-            self.log.error("No tarball found at %s" % fn_pattern)
+            raise EasyBuildError("No tarball found at %s", fn_pattern)
         elif len(matches) > 1:
-            self.log.error("Multiple matches found for tarball: %s" % matches)
+            raise EasyBuildError("Multiple matches found for tarball: %s", matches)
         else:
             tarball = matches[0]
             self.log.info("Tarball found at %s" % tarball)
@@ -99,14 +100,14 @@ class EB_python_minus_meep(PythonPackage):
         tmpdir = tempfile.mkdtemp()
         srcdir = extract_file(tarball, tmpdir)
         if not srcdir:
-            self.log.error("Unpacking tarball %s failed?" % tarball)
+            raise EasyBuildError("Unpacking tarball %s failed?", tarball)
 
         # locate site-packages dir to copy by diving into unpacked tarball
         src = srcdir
         while len(os.listdir(src)) == 1:
             src = os.path.join(src, os.listdir(src)[0])
         if not os.path.basename(src) =='site-packages':
-            self.log.error("Expected to find a site-packages path, but found something else: %s" % src)
+            raise EasyBuildError("Expected to find a site-packages path, but found something else: %s", src)
 
         # copy contents of site-packages dir
         dest = os.path.join(self.installdir, 'site-packages')
@@ -115,7 +116,7 @@ class EB_python_minus_meep(PythonPackage):
             rmtree2(tmpdir)
             os.chdir(self.installdir)
         except OSError, err:
-            self.log.exception("Failed to copy directory %s to %s: %s" % (src, dest, err))
+            raise EasyBuildError("Failed to copy directory %s to %s: %s", src, dest, err)
 
     def sanity_check_step(self):
 

--- a/easybuild/easyblocks/q/qt.py
+++ b/easybuild/easyblocks/q/qt.py
@@ -31,6 +31,7 @@ import os
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd_qa
 
 
@@ -50,7 +51,7 @@ class EB_Qt(ConfigureMake):
         elif comp_fam in [toolchain.INTELCOMP]:  #@UndefinedVariable
             self.cfg.update('configopts', '-platform linux-icc-64')
         else:
-            self.log.error("Don't know which platform to set based on compiler family.")
+            raise EasyBuildError("Don't know which platform to set based on compiler family.")
 
         cmd = "%s ./configure --prefix=%s %s" % (self.cfg['preconfigopts'], self.installdir, self.cfg['configopts'])
         qa = {

--- a/easybuild/easyblocks/q/quantumespresso.py
+++ b/easybuild/easyblocks/q/quantumespresso.py
@@ -38,6 +38,7 @@ import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 
 
@@ -162,7 +163,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
 
                 sys.stdout.write(line)
         except IOError, err:
-            self.log.error("Failed to patch %s: %s" % (fn, err))
+            raise EasyBuildError("Failed to patch %s: %s", fn, err)
 
         self.log.debug("Contents of patched %s: %s" % (fn, open(fn, "r").read()))
 
@@ -178,7 +179,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
                 sys.stdout.write(line)
 
         except IOError, err:
-            self.log.error("Failed to patch %s: %s" % (fn, err))
+            raise EasyBuildError("Failed to patch %s: %s", fn, err)
 
         self.log.debug("Contents of patched %s: %s" % (fn, open(fn, "r").read()))
 
@@ -187,7 +188,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
         wantdirs = [d for d in os.listdir(self.builddir) if d.startswith(wantprefix)]
 
         if len(wantdirs) > 1:
-            self.log.error("Found more than one directory with %s prefix, help!" % wantprefix)
+            raise EasyBuildError("Found more than one directory with %s prefix, help!", wantprefix)
 
         if len(wantdirs) != 0:
             fn = os.path.join(self.builddir, wantdirs[0], 'conf', 'make.sys.in')
@@ -202,7 +203,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
 
                     sys.stdout.write(line)
             except IOError, err:
-                self.log.error("Failed to patch %s: %s" % (fn, err))
+                raise EasyBuildError("Failed to patch %s: %s", fn, err)
 
         # move non-espresso directories to where they're expected and create symlinks
         try:
@@ -224,7 +225,7 @@ class EB_QuantumESPRESSO(ConfigureMake):
                     os.symlink(os.path.join(targetdir, dirname), os.path.join(targetdir, linkname))
 
         except OSError, err:
-            self.log.error("Failed to move non-espresso directories: %s" % err)
+            raise EasyBuildError("Failed to move non-espresso directories: %s", err)
 
     def install_step(self):
         """Skip install step, since we're building in the install directory."""

--- a/easybuild/easyblocks/r/rosetta.py
+++ b/easybuild/easyblocks/r/rosetta.py
@@ -40,6 +40,7 @@ import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.icc import get_icc_version
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import extract_file
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
@@ -68,9 +69,10 @@ class EB_Rosetta(EasyBlock):
                 if os.path.isfile(src_tarball):
                     self.srcdir = extract_file(src_tarball, prefix)
                 else:
-                    self.log.error("Neither source directory '%s', nor source tarball '%s' found." % (self.srcdir, src_tarball))
+                    raise EasyBuildError("Neither source directory '%s', nor source tarball '%s' found.",
+                                         self.srcdir, src_tarball)
         except OSError, err:
-            self.log.error("Getting Rosetta sources dir ready failed: %s" % err)
+            raise EasyBuildError("Getting Rosetta sources dir ready failed: %s", err)
 
     def configure_step(self):
         """
@@ -89,7 +91,7 @@ class EB_Rosetta(EasyBlock):
         elif self.toolchain.comp_family() in [toolchain.INTELCOMP]:  #@UndefinedVariable
             cxx_ver = '.'.join(get_icc_version().split('.')[:2])
         else:
-            self.log.error("Don't know how to determine C++ compiler version.")
+            raise EasyBuildError("Don't know how to determine C++ compiler version.")
         self.cfg.update('buildopts', "cxx=%s cxx_ver=%s" % (self.cxx, cxx_ver))
 
         if self.toolchain.options.get('usempi', None):
@@ -151,7 +153,7 @@ class EB_Rosetta(EasyBlock):
             f.write(txt)
             f.close()
         except IOError, err:
-            self.log.error("Failed to write settings file %s: %s" % (us_fp, err))
+            raise EasyBuildError("Failed to write settings file %s: %s", us_fp, err)
 
         # make sure specified compiler version is accepted by patching it in
         os_fp = os.path.join(self.srcdir, "tools/build/options.settings")
@@ -167,7 +169,7 @@ class EB_Rosetta(EasyBlock):
         try:
             os.chdir(self.srcdir)
         except OSError, err:
-            self.log.error("Failed to change to %s: %s" % (self.srcdir, err))
+            raise EasyBuildError("Failed to change to %s: %s", self.srcdir, err)
         par = ''
         if self.cfg['parallel']:
             par = "-j %s" % self.cfg['parallel']
@@ -185,7 +187,7 @@ class EB_Rosetta(EasyBlock):
             os.makedirs(bindir)
             os.makedirs(libdir)
         except OSError, err:
-            self.log.error("Failed to created bin/lib dirs: %s, %s" % (bindir, libdir))
+            raise EasyBuildError("Failed to created bin/lib dirs: %s, %s", bindir, libdir)
 
         for build_subdir in ['src', 'external']:
             builddir = os.path.join('build', build_subdir)
@@ -196,7 +198,7 @@ class EB_Rosetta(EasyBlock):
                 while len(os.listdir(builddir)) == 1:
                     builddir = os.path.join(builddir, os.listdir(builddir)[0])
             except OSError, err:
-                self.log.error("Failed to walk build/src dir: %s" % err)
+                raise EasyBuildError("Failed to walk build/src dir: %s", err)
             # copy binaries/libraries to install dir
             lib_re = re.compile("^lib.*\.so$")
             try:
@@ -210,7 +212,7 @@ class EB_Rosetta(EasyBlock):
                             self.log.debug("Copying %s to %s" % (srcfile, bindir))
                             shutil.copy2(srcfile, os.path.join(bindir, fil))
             except OSError, err:
-                self.log.error("Copying executables from %s to bin/lib install dirs failed: %s" % (builddir, err))
+                raise EasyBuildError("Copying executables from %s to bin/lib install dirs failed: %s", builddir, err)
 
         os.chdir(self.cfg['start_dir'])
 
@@ -227,9 +229,10 @@ class EB_Rosetta(EasyBlock):
                 if os.path.exists(srcdir):
                     shutil.copytree(srcdir, os.path.join(self.installdir, os.path.basename(srcdir)))
                 elif not optional:
-                    self.log.error("Neither source directory '%s', nor source tarball '%s' found." % srcdir, src_tarball)
+                    raise EasyBuildError("Neither source directory '%s', nor source tarball '%s' found.",
+                                         srcdir, src_tarball)
             except OSError, err:
-                self.log.error("Getting Rosetta %s dir ready failed: %s" % (dirname_tmpl, err))
+                raise EasyBuildError("Getting Rosetta %s dir ready failed: %s", dirname_tmpl, err)
 
         # (extract and) copy database and biotools (if it's there)
         extract_and_copy('rosetta_database%s')

--- a/easybuild/easyblocks/s/samtools.py
+++ b/easybuild/easyblocks/s/samtools.py
@@ -22,6 +22,7 @@ import stat
 from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import adjust_permissions
 
 class EB_SAMtools(ConfigureMake):
@@ -93,7 +94,7 @@ class EB_SAMtools(ConfigureMake):
                     srcfile = os.path.join(srcdir, filename)
                     shutil.copy2(srcfile, destdir)
             except OSError, err:
-                self.log.error("Copying %s to installation dir %s failed: %s" % (srcfile, destdir, err))
+                raise EasyBuildError("Copying %s to installation dir %s failed: %s", srcfile, destdir, err)
 
         # fix permissions so ownwer group and others have R-X
         adjust_permissions(self.installdir, stat.S_IRGRP|stat.S_IXGRP|stat.S_IROTH|stat.S_IXOTH, add=True, recursive=True)

--- a/easybuild/easyblocks/s/scalapack.py
+++ b/easybuild/easyblocks/s/scalapack.py
@@ -65,7 +65,7 @@ class EB_ScaLAPACK(ConfigureMake):
         try:
             shutil.copy(src, dest)
         except OSError, err:
-            raise EasyBuildError("Symlinking %s to, failed: %s", src, dest, err)
+            raise EasyBuildError("Symlinking %s to %s failed: %s", src, dest, err)
 
         self.loosever = LooseVersion(self.version)
 

--- a/easybuild/easyblocks/s/scalapack.py
+++ b/easybuild/easyblocks/s/scalapack.py
@@ -41,6 +41,7 @@ import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.blacs import det_interface  #@UnresolvedImport
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.easyblocks.lapack import get_blas_lib as lapack_get_blas_lib  #@UnresolvedImport
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 
 
@@ -56,15 +57,15 @@ class EB_ScaLAPACK(ConfigureMake):
         dest = os.path.join(self.cfg['start_dir'], 'SLmake.inc')
 
         if not os.path.isfile(src):
-            self.log.error("Can't fin source file %s" % src)
+            raise EasyBuildError("Can't fin source file %s", src)
 
         if os.path.exists(dest):
-            self.log.error("Destination file %s exists" % dest)
+            raise EasyBuildError("Destination file %s exists", dest)
 
         try:
             shutil.copy(src, dest)
         except OSError, err:
-            self.log.error("Symlinking %s to % failed: %s" % (src, dest, err))
+            raise EasyBuildError("Symlinking %s to, failed: %s", src, dest, err)
 
         self.loosever = LooseVersion(self.version)
 
@@ -81,7 +82,7 @@ class EB_ScaLAPACK(ConfigureMake):
                     ok = True
                     break
             if not ok:
-                self.log.error("None of the following dependencies %s are available/loaded." % (depgrp, ))
+                raise EasyBuildError("None of the following dependencies %s are available/loaded.", str(depgrp))
 
     def build_step(self):
         """Build ScaLAPACK using make after setting make options."""
@@ -98,7 +99,7 @@ class EB_ScaLAPACK(ConfigureMake):
             mpif77 = 'mpif77'
             mpif90 = 'mpif90'
         else:
-            self.log.error("Don't know which compiler commands to use.")
+            raise EasyBuildError("Don't know which compiler commands to use.")
 
         # set BLAS and LAPACK libs
         extra_makeopts = None
@@ -122,7 +123,7 @@ class EB_ScaLAPACK(ConfigureMake):
                 'LAPACKLIB="%s"' % lapack_get_blas_lib(self.log),
             ]
         else:
-            self.log.error("LAPACK, ACML or OpenBLAS are not available, no idea how to set BLASLIB/LAPACKLIB make options.")
+            raise EasyBuildError("LAPACK, ACML or OpenBLAS are not available, no idea how to set BLASLIB/LAPACKLIB make options.")
 
         # build procedure changed in v2.0.0
         if self.loosever < LooseVersion("2.0.0"):
@@ -166,7 +167,7 @@ class EB_ScaLAPACK(ConfigureMake):
             if self.toolchain.mpi_family() in known_mpi_libs:
                 interface = 'Add_'
             else:
-                self.log.error("Don't know which interface to pick for the MPI library being used.")
+                raise EasyBuildError("Don't know which interface to pick for the MPI library being used.")
 
             # set compilers and options
             extra_makeopts += [
@@ -209,7 +210,7 @@ class EB_ScaLAPACK(ConfigureMake):
                     self.log.debug("Copied %s to %s" % (lib, dest))
 
             except OSError, err:
-                self.log.error("Copying %s/*.%s to installation dir %s failed: %s" % (src, ext, dest, err))
+                raise EasyBuildError("Copying %s/*.%s to installation dir %s failed: %s", src, ext, dest, err)
 
     def sanity_check_step(self):
         """Custom sanity check for ScaLAPACK."""

--- a/easybuild/easyblocks/s/scalasca1.py
+++ b/easybuild/easyblocks/s/scalasca1.py
@@ -33,6 +33,7 @@ from distutils.version import LooseVersion
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 
 
@@ -43,9 +44,9 @@ class EB_Scalasca1(ConfigureMake):
         """Make sure this easyblock is applicable to the Scalasca version being built."""
         ver = LooseVersion(self.version)
         if ver >= LooseVersion('2.0') or ver < LooseVersion('1.0'):
-            msg = "The %s easyblock should only be used for Scalasca v1.x; " % self.__class__.__name__
-            msg += "for Scalasca v2.0 and more recent, try the EB_Score_minus_P easyblock."
-            self.log.error(msg)
+            raise EasyBuildError("The %s easyblock should only be used for Scalasca v1.x; "
+                                 "for Scalasca v2.0 and more recent, try the EB_Score_minus_P easyblock.",
+                                 self.__class__.__name__)
 
         super(EB_Scalasca1, self).check_readiness_step()
 
@@ -62,7 +63,8 @@ class EB_Scalasca1(ConfigureMake):
         if comp_fam in comp_opts:
             self.cfg.update('configopts', "--compiler=%s" % comp_opts[comp_fam])
         else:
-            self.log.error("Compiler family %s not supported yet (only: %s)" % (comp_fam, ', '.join(comp_opts.keys())))
+            raise EasyBuildError("Compiler family %s not supported yet (only: %s)",
+                                 comp_fam, ', '.join(comp_opts.keys()))
 
         mpi_opts = {
             toolchain.INTELMPI: 'intel2',  # intel: Intel MPI v1.x (ancient)
@@ -74,7 +76,7 @@ class EB_Scalasca1(ConfigureMake):
         if mpi_fam in mpi_opts:
             self.cfg.update('configopts', "--mpi=%s --enable-all-mpi-wrappers" % mpi_opts[mpi_fam])
         else:
-            self.log.error("MPI family %s not supported yet (only: %s)" % (mpi_fam, ', '.join(mpi_opts.keys())))
+            raise EasyBuildError("MPI family %s not supported yet (only: %s)", mpi_fam, ', '.join(mpi_opts.keys()))
 
         # auto-detection for dependencies mostly works fine, but hard specify paths anyway to have full control
         deps = {
@@ -104,7 +106,7 @@ class EB_Scalasca1(ConfigureMake):
                     build_dir_found = True
                     self.log.info("Stepped into build dir %s" % entry)
         except OSError, err:
-            self.log.error("Failed to step into build dir before starting actual build: %s" % err)
+            raise EasyBuildError("Failed to step into build dir before starting actual build: %s", err)
         if not build_dir_found:
-            self.log.error("Could not find build dir to step into.")
+            raise EasyBuildError("Could not find build dir to step into.")
         super(EB_Scalasca1, self).build_step()

--- a/easybuild/easyblocks/s/score_p.py
+++ b/easybuild/easyblocks/s/score_p.py
@@ -32,6 +32,7 @@ import os
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root, get_software_libdir
 
 
@@ -52,7 +53,8 @@ class EB_Score_minus_P(ConfigureMake):
         if comp_fam in comp_opts:
             self.cfg.update('configopts', "--with-nocross-compiler-suite=%s" % comp_opts[comp_fam])
         else:
-            self.log.error("Compiler family %s not supported yet (only: %s)" % (comp_fam, ', '.join(comp_opts.keys())))
+            raise EasyBuildError("Compiler family %s not supported yet (only: %s)",
+                                 comp_fam, ', '.join(comp_opts.keys()))
 
         mpi_opts = {
             toolchain.INTELMPI: 'intel2',  # intel: Intel MPI v1.x (ancient); intelpoe: IBM POE MPI for Intel platforms
@@ -64,7 +66,7 @@ class EB_Score_minus_P(ConfigureMake):
         if mpi_fam in mpi_opts:
             self.cfg.update('configopts', "--with-mpi=%s" % mpi_opts[mpi_fam])
         else:
-            self.log.error("MPI family %s not supported yet (only: %s)" % (mpi_fam, ', '.join(mpi_opts.keys())))
+            raise EasyBuildError("MPI family %s not supported yet (only: %s)", mpi_fam, ', '.join(mpi_opts.keys()))
 
         # auto-detection for dependencies mostly works fine, but hard specify paths anyway to have full control
         deps = {

--- a/easybuild/easyblocks/s/scotch.py
+++ b/easybuild/easyblocks/s/scotch.py
@@ -40,6 +40,7 @@ from distutils.version import LooseVersion
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import copytree
 from easybuild.tools.run import run_cmd
 
@@ -57,7 +58,7 @@ class EB_SCOTCH(EasyBlock):
         elif comp_fam == toolchain.GCC:  #@UndefinedVariable
             makefilename = 'Makefile.inc.x86-64_pc_linux2'
         else:
-            self.log.error("Unknown compiler family used: %s" % comp_fam)
+            raise EasyBuildError("Unknown compiler family used: %s", comp_fam)
 
         # create Makefile.inc
         try:
@@ -67,7 +68,7 @@ class EB_SCOTCH(EasyBlock):
             shutil.copy2(src, dst)
             self.log.debug("Successfully copied Makefile.inc to src dir.")
         except OSError:
-            self.log.error("Copying Makefile.inc to src dir failed.")
+            raise EasyBuildError("Copying Makefile.inc to src dir failed.")
 
         # the default behaviour of these makefiles is still wrong
         # e.g., compiler settings, and we need -lpthread
@@ -81,14 +82,14 @@ class EB_SCOTCH(EasyBlock):
                 line = re.sub(r"^LDFLAGS\s*=(?P<ldflags>.*$)", "LDFLAGS\t=\g<ldflags> -lpthread", line)
                 sys.stdout.write(line)
         except IOError, err:
-            self.log.error("Can't modify/write Makefile in 'Makefile.inc': %s" % (err))
+            raise EasyBuildError("Can't modify/write Makefile in 'Makefile.inc': %s", err)
 
         # change to src dir for building
         try:
             os.chdir(srcdir)
             self.log.debug("Changing to src dir.")
         except OSError, err:
-            self.log.error("Failed to change to src dir: %s" % err)
+            raise EasyBuildError("Failed to change to src dir: %s", err)
 
     def build_step(self):
         """Build by running build_step, but with some special options for SCOTCH depending on the compiler."""
@@ -130,7 +131,7 @@ class EB_SCOTCH(EasyBlock):
                 copytree(src, dst, ignore=lambda path, files: [x for x in files if regmetis.match(x)])
 
         except OSError, err:
-            self.log.error("Copying %s to installation dir %s failed: %s" % (src, dst, err))
+            raise EasyBuildError("Copying %s to installation dir %s failed: %s", src, dst, err)
 
         # create group library file
         scotchlibdir = os.path.join(self.installdir, 'lib')
@@ -145,7 +146,7 @@ class EB_SCOTCH(EasyBlock):
             f.close()
             self.log.info("Successfully written group lib file: %s" % scotchgrouplib)
         except (IOError, OSError), err:
-            self.log.error("Can't write to file %s: %s" % (scotchgrouplib, err))
+            raise EasyBuildError("Can't write to file %s: %s", scotchgrouplib, err)
 
     def sanity_check_step(self):
         """Custom sanity check for SCOTCH."""

--- a/easybuild/easyblocks/s/shrimp.py
+++ b/easybuild/easyblocks/s/shrimp.py
@@ -33,6 +33,7 @@ import shutil
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 
 
 class EB_SHRiMP(ConfigureMake):
@@ -62,7 +63,7 @@ class EB_SHRiMP(ConfigureMake):
             os.chdir(cwd)
 
         except OSError, err:
-            self.log.error("Failed to copy files to install dir: %s" % err)
+            raise EasyBuildError("Failed to copy files to install dir: %s", err)
 
 
     def sanity_check_step(self):

--- a/easybuild/easyblocks/s/slepc.py
+++ b/easybuild/easyblocks/s/slepc.py
@@ -34,6 +34,7 @@ import re
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import BUILD, CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
 
@@ -73,7 +74,7 @@ class EB_SLEPc(ConfigureMake):
 
         # check PETSc dependency
         if not get_software_root("PETSc"):
-            self.log.error("PETSc module not loaded?")
+            raise EasyBuildError("PETSc module not loaded?")
 
         # set SLEPC_DIR environment variable
         env.setvar('SLEPC_DIR', self.cfg['start_dir'])
@@ -103,7 +104,7 @@ class EB_SLEPc(ConfigureMake):
         # check for errors in configure
         error_regexp = re.compile("ERROR")
         if error_regexp.search(out):
-            self.log.error("Error(s) detected in configure output!")
+            raise EasyBuildError("Error(s) detected in configure output!")
 
         # set default PETSC_ARCH if required
         if not os.getenv('PETSC_ARCH'):

--- a/easybuild/easyblocks/s/soapdenovo.py
+++ b/easybuild/easyblocks/s/soapdenovo.py
@@ -20,6 +20,7 @@ import os
 import shutil
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 
 
 class EB_SOAPdenovo(ConfigureMake):
@@ -52,7 +53,7 @@ class EB_SOAPdenovo(ConfigureMake):
                 srcfile = os.path.join(srcdir, "bin", "SOAPdenovo-%s" % suff)
                 shutil.copy2(srcfile, destdir)
         except OSError, err:
-            self.log.error("Copying %s to installation dir %s failed: %s" % (srcfile, destdir, err))
+            raise EasyBuildError("Copying %s to installation dir %s failed: %s", srcfile, destdir, err)
 
     def sanity_check_step(self):
         """Custom sanity check for SOAPdenovo."""

--- a/easybuild/easyblocks/s/suitesparse.py
+++ b/easybuild/easyblocks/s/suitesparse.py
@@ -137,8 +137,8 @@ class EB_SuiteSparse(ConfigureMake):
                             os.symlink(nsrc, ndst)
                 else:
                     shutil.copy2(src, dst)
-            except:
-                raise EasyBuildError("Copying src %s to dst %s failed", src, dst)
+            except OSError, err:
+                raise EasyBuildError("Copying src %s to dst %s failed: %s", src, dst, err)
 
         # some extra symlinks are necessary for UMFPACK to work.
         paths = [
@@ -156,7 +156,7 @@ class EB_SuiteSparse(ConfigureMake):
             if os.path.exists(src):
                 try:
                     os.symlink(src, os.path.join(dstdir, fn))
-                except Exception, err:
+                except OSError, err:
                     raise EasyBuildError("Failed to make symbolic link from %s to %s: %s", src, dst, err)
 
     def make_module_req_guess(self):

--- a/easybuild/easyblocks/s/suitesparse.py
+++ b/easybuild/easyblocks/s/suitesparse.py
@@ -39,6 +39,7 @@ import sys
 from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import mkdir
 from easybuild.tools.modules import get_software_root
 
@@ -81,7 +82,7 @@ class EB_SuiteSparse(ConfigureMake):
             metis_path = metis
             metis_libs = os.path.join(metis, 'lib', 'metis.a')
         else:
-            self.log.error("Neither METIS or ParMETIS module loaded.")
+            raise EasyBuildError("Neither METIS or ParMETIS module loaded.")
 
         cfgvars.update({
             'METIS_PATH': metis_path,
@@ -105,7 +106,7 @@ class EB_SuiteSparse(ConfigureMake):
                         cfgvars.pop(var)
                 sys.stdout.write(line)
         except IOError, err:
-            self.log.error("Failed to patch %s in: %s" % (fp, err))
+            raise EasyBuildError("Failed to patch %s in: %s", fp, err)
 
         # add remaining entries at the end
         if cfgvars:
@@ -116,7 +117,7 @@ class EB_SuiteSparse(ConfigureMake):
                     f.write("%s = %s\n" % (var, val))
                 f.close()
             except IOError, err:
-                self.log.error("Failed to complete %s: %s" % (fp, err))
+                raise EasyBuildError("Failed to complete %s: %s", fp, err)
 
     def install_step(self):
         """Install by copying the contents of the builddir to the installdir (preserving permissions)"""
@@ -137,7 +138,7 @@ class EB_SuiteSparse(ConfigureMake):
                 else:
                     shutil.copy2(src, dst)
             except:
-                self.log.exception("Copying src %s to dst %s failed" % (src, dst))
+                raise EasyBuildError("Copying src %s to dst %s failed", src, dst)
 
         # some extra symlinks are necessary for UMFPACK to work.
         paths = [
@@ -156,7 +157,7 @@ class EB_SuiteSparse(ConfigureMake):
                 try:
                     os.symlink(src, os.path.join(dstdir, fn))
                 except Exception, err:
-                    self.log.error("Failed to make symbolic link from %s to %s: %s" % (src, dst, err))
+                    raise EasyBuildError("Failed to make symbolic link from %s to %s: %s", src, dst, err)
 
     def make_module_req_guess(self):
         """Add config dir to CPATH so include file is found."""

--- a/easybuild/easyblocks/s/swig.py
+++ b/easybuild/easyblocks/s/swig.py
@@ -28,6 +28,7 @@ EasyBuild support for SWIG, implemented as an easyblock
 @author: Kenneth Hoste (Ghent University)
 """
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 
 
@@ -47,7 +48,7 @@ class EB_SWIG(ConfigureMake):
         if python:
             self.cfg.update('configopts', "--with-python=%s/bin/python" % python)
         else:
-            self.log.error("Python module not loaded?")
+            raise EasyBuildError("Python module not loaded?")
 
         super(EB_SWIG, self).configure_step()
 

--- a/easybuild/easyblocks/t/tbb.py
+++ b/easybuild/easyblocks/t/tbb.py
@@ -38,6 +38,7 @@ import glob
 from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.intelbase import IntelBase, ACTIVATION_NAME_2012, LICENSE_FILE_NAME_2012
+from easybuild.tools.build_log import EasyBuildError
 
 
 class EB_tbb(IntelBase):
@@ -67,7 +68,7 @@ class EB_tbb(IntelBase):
             # we're only interested in the last bit
             libdir = libdir.split('/')[-1]
         else:
-            self.log.error("No libs found using %s in %s" % (libglob, self.installdir))
+            raise EasyBuildError("No libs found using %s in %s", libglob, self.installdir)
         self.libdir = libdir
 
 

--- a/easybuild/easyblocks/t/trilinos.py
+++ b/easybuild/easyblocks/t/trilinos.py
@@ -35,6 +35,7 @@ from distutils.version import LooseVersion
 import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 
 
@@ -206,7 +207,7 @@ class EB_Trilinos(CMakeMake):
             os.mkdir(build_dir)
             os.chdir(build_dir)
         except OSError, err:
-            self.log.error("Failed to create and move into build directory: %s" % err)
+            raise EasyBuildError("Failed to create and move into build directory: %s", err)
 
         # configure using cmake
         super(EB_Trilinos, self).configure_step(srcdir="..")

--- a/easybuild/easyblocks/t/trinity.py
+++ b/easybuild/easyblocks/t/trinity.py
@@ -75,7 +75,7 @@ class EB_Trinity(EasyBlock):
         try:
             os.chdir(dst)
         except OSError, err:
-            raise EasyBuildError("Butterfly: failed to change to dst dir %s", dst, err)
+            raise EasyBuildError("Butterfly: failed to change to dst dir %s: %s", dst, err)
 
         cmd = "ant"
         run_cmd(cmd)

--- a/easybuild/easyblocks/t/trinity.py
+++ b/easybuild/easyblocks/t/trinity.py
@@ -42,6 +42,7 @@ from distutils.version import LooseVersion
 import easybuild.tools.toolchain as toolchain
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
 
@@ -74,7 +75,7 @@ class EB_Trinity(EasyBlock):
         try:
             os.chdir(dst)
         except OSError, err:
-            self.log.error("Butterfly: failed to change to dst dir %s" % (dst, err))
+            raise EasyBuildError("Butterfly: failed to change to dst dir %s", dst, err)
 
         cmd = "ant"
         run_cmd(cmd)
@@ -99,7 +100,7 @@ class EB_Trinity(EasyBlock):
             try:
                 os.chdir(dst)
             except OSError, err:
-                self.log.error("Chrysalis: failed to change to dst dir %s: %s" % (dst, err))
+                raise EasyBuildError("Chrysalis: failed to change to dst dir %s: %s", dst, err)
 
             run_cmd("make clean")
             run_cmd("make %s" % make_flags)
@@ -121,7 +122,7 @@ class EB_Trinity(EasyBlock):
             try:
                 os.chdir(dst)
             except OSError, err:
-                self.log.error("Inchworm: failed to change to dst dir %s: %s" % (dst, err))
+                raise EasyBuildError("Inchworm: failed to change to dst dir %s: %s", dst, err)
 
             run_cmd('./configure --prefix=%s' % dst)
             run_cmd("make install %s" % make_flags)
@@ -154,7 +155,7 @@ class EB_Trinity(EasyBlock):
                 os.symlink(jellyfishdir, orig_jellyfishdir)
                 os.chdir(orig_jellyfishdir)
             except OSError, err:
-                self.log.error("jellyfish plugin: failed to change dir %s: %s" % (orig_jellyfishdir, err))
+                raise EasyBuildError("jellyfish plugin: failed to change dir %s: %s", orig_jellyfishdir, err)
 
             run_cmd('./configure --prefix=%s' % orig_jellyfishdir)
             cmd = "make CC='%s' CXX='%s' CFLAGS='%s'" % (os.getenv('CC'), os.getenv('CXX'), os.getenv('CFLAGS'))
@@ -167,9 +168,9 @@ class EB_Trinity(EasyBlock):
             try:
                 os.chdir(cwd)
             except OSError:
-                self.log.error("jellyfish: Could not return to original dir %s", cwd)
+                raise EasyBuildError("jellyfish: Could not return to original dir %s", cwd)
         elif jellyfishdirs:
-            self.log.error("Found multiple 'jellyfish-*' directories: %s", jellyfishdirs)
+            raise EasyBuildError("Found multiple 'jellyfish-*' directories: %s", jellyfishdirs)
         else:
             self.log.info("no seperate source found for jellyfish, letting Makefile build shipped version")
 
@@ -184,7 +185,7 @@ class EB_Trinity(EasyBlock):
         try:
             os.chdir(dst)
         except OSError, err:
-            self.log.error("Meryl: failed to change to dst dir %s: %s" % (dst, err))
+            raise EasyBuildError("Meryl: failed to change to dst dir %s: %s", dst, err)
 
         cmd = "./configure.sh"
         run_cmd(cmd)
@@ -206,7 +207,7 @@ class EB_Trinity(EasyBlock):
         try:
             os.chdir(dst)
         except OSError, err:
-            self.log.error("%s plugin: failed to change to dst dir %s: %s" % (plugindir, dst, err))
+            raise EasyBuildError("%s plugin: failed to change to dst dir %s: %s", plugindir, dst, err)
 
         if not cc:
             cc = os.getenv('CC')
@@ -276,7 +277,7 @@ class EB_Trinity(EasyBlock):
             elif comp_fam in [toolchain.GCC]:
                 trinity_compiler = "gcc"
             else:
-                self.log.error("Don't know how to set TRINITY_COMPILER for %s compiler" % comp_fam)
+                raise EasyBuildError("Don't know how to set TRINITY_COMPILER for %s compiler", comp_fam)
 
             cmd = "make TRINITY_COMPILER=%s" % trinity_compiler
             run_cmd(cmd)
@@ -289,7 +290,7 @@ class EB_Trinity(EasyBlock):
             try:
                 shutil.rmtree(os.path.join(self.cfg['start_dir'], 'sample_data'))
             except OSError, err:
-                self.log.error("Failed to remove sample data: %s" % err)
+                raise EasyBuildError("Failed to remove sample data: %s", err)
 
     def sanity_check_step(self):
         """Custom sanity check for Trinity."""

--- a/easybuild/easyblocks/u/ufc.py
+++ b/easybuild/easyblocks/u/ufc.py
@@ -30,6 +30,7 @@ EasyBuild support for UFC, implemented as an easyblock
 from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.cmakepythonpackage import CMakePythonPackage
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root, get_software_version
 
 
@@ -51,7 +52,7 @@ class EB_UFC(CMakePythonPackage):
         for dep in deps:
             deproot = get_software_root(dep)
             if not deproot:
-                self.log.error("%s module not loaded?" % dep)
+                raise EasyBuildError("%s module not loaded?", dep)
             else:
                 depsdict.update({dep:deproot})
 
@@ -59,8 +60,8 @@ class EB_UFC(CMakePythonPackage):
         # which causes problems with e.g. DOLFIN if UFC was built with it
         # fixed in 2.0.7? see https://bugs.launchpad.net/dolfin/+bug/996398
         if LooseVersion(get_software_version('SWIG')) > '2.0.4':
-            self.log.error("Using bad version of SWIG, expecting swig <= 2.0.4." \
-                           " See https://bugs.launchpad.net/dolfin/+bug/996398")
+            raise EasyBuildError("Using bad version of SWIG, expecting swig <= 2.0.4. "
+                                 "See https://bugs.launchpad.net/dolfin/+bug/996398")
 
         self.pyver = ".".join(get_software_version('Python').split(".")[:-1])
 

--- a/easybuild/easyblocks/v/velvet.py
+++ b/easybuild/easyblocks/v/velvet.py
@@ -20,6 +20,7 @@ import os
 import shutil
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 
 
 class EB_Velvet(ConfigureMake):
@@ -45,7 +46,7 @@ class EB_Velvet(ConfigureMake):
                 srcfile = os.path.join(srcdir, filename)
                 shutil.copy2(srcfile, destdir)
         except OSError, err:
-            self.log.error("Copying %s to installation dir %s failed: %s" % (srcfile, destdir, err))
+            raise EasyBuildError("Copying %s to installation dir %s failed: %s", srcfile, destdir, err)
 
     def sanity_check_step(self):
         """Custom sanity check for Velvet."""

--- a/easybuild/easyblocks/v/vsc_tools.py
+++ b/easybuild/easyblocks/v/vsc_tools.py
@@ -32,6 +32,7 @@ import os
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.pythonpackage import PythonPackage
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
 
 
@@ -61,7 +62,7 @@ class EB_VSC_minus_tools(PythonPackage):
                 os.chdir(self.builddir)
                 sel_dirs = [d for d in glob.glob("%s-[0-9][0-9.]*" % pkg)]
                 if not len(sel_dirs) == 1:
-                    self.log.error("Found none or more than one %s dir in %s: %s" % (pkg, self.builddir, sel_dirs))
+                    raise EasyBuildError("Found none or more than one %s dir in %s: %s", pkg, self.builddir, sel_dirs)
 
                 os.chdir(os.path.join(self.builddir, sel_dirs[0]))
                 cmd = "python setup.py %s" % args
@@ -70,7 +71,7 @@ class EB_VSC_minus_tools(PythonPackage):
             os.chdir(pwd)
 
         except OSError, err:
-            self.log.error("Failed to install: %s" % err)
+            raise EasyBuildError("Failed to install: %s", err)
 
     def sanity_check_step(self):
         """Custom sanity check for VSC-tools."""

--- a/easybuild/easyblocks/w/wps.py
+++ b/easybuild/easyblocks/w/wps.py
@@ -44,6 +44,7 @@ import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.netcdf import set_netcdf_env_vars, get_netcdf_module_set_cmds  #@UnresolvedImport
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM, MANDATORY
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import extract_file, patch_perl_script_autoflush, rmtree2
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd, run_cmd_qa
@@ -94,7 +95,7 @@ class EB_WPS(EasyBlock):
             majver = get_software_version('WRF').split('.')[0]
             self.wrfdir = os.path.join(wrf, "WRFV%s" % majver)
         else:
-            self.log.error("WRF module not loaded?")
+            raise EasyBuildError("WRF module not loaded?")
 
         # patch compile script so that WRF is found
         self.compile_script = "compile"
@@ -103,7 +104,7 @@ class EB_WPS(EasyBlock):
                 line = re.sub(r"^(\s*set\s*WRF_DIR_PRE\s*=\s*)\${DEV_TOP}(.*)$", r"\1%s\2" % self.wrfdir, line)
                 sys.stdout.write(line)
         except IOError, err:
-            self.log.error("Failed to patch %s script: %s" % (self.compile_script, err))
+            raise EasyBuildError("Failed to patch %s script: %s", self.compile_script, err)
 
         # libpng dependency check
         libpng = get_software_root('libpng')
@@ -115,7 +116,7 @@ class EB_WPS(EasyBlock):
             libpnginc = ' '.join(['-I%s' % os.path.join(path, 'include') for path in paths])
             libpnglib = ' '.join(['-L%s' % os.path.join(path, 'lib') for path in paths])
         else:
-            self.log.error("libpng module not loaded?")
+            raise EasyBuildError("libpng module not loaded?")
 
         # JasPer dependency check + setting env vars
         jasper = get_software_root('JasPer')
@@ -125,7 +126,7 @@ class EB_WPS(EasyBlock):
             env.setvar('JASPERLIB', jasperlibdir)
             jasperlib = "-L%s" % jasperlibdir
         else:
-            self.log.error("JasPer module not loaded?")
+            raise EasyBuildError("JasPer module not loaded?")
 
         # patch ungrib Makefile so that JasPer is found
         fn = os.path.join("ungrib", "src", "Makefile")
@@ -136,7 +137,7 @@ class EB_WPS(EasyBlock):
                 line = re.sub(r"^(\s*\$\(COMPRESSION_LIBS\))(\s*;.*)$", r"\1 %s\2" % jasperlibs, line)
                 sys.stdout.write(line)
         except IOError, err:
-            self.log.error("Failed to patch %s: %s" % (fn, err))
+            raise EasyBuildError("Failed to patch %s: %s", fn, err)
 
         # patch arch/Config.pl script, so that run_cmd_qa receives all output to answer questions
         patch_perl_script_autoflush(os.path.join("arch", "Config.pl"))
@@ -161,7 +162,7 @@ class EB_WPS(EasyBlock):
                 build_type_option = "Linux x86_64 g95 compiler"
 
             else:
-                self.log.error("Don't know how to figure out build type to select.")
+                raise EasyBuildError("Don't know how to figure out build type to select.")
 
         else:
 
@@ -178,13 +179,13 @@ class EB_WPS(EasyBlock):
                 knownbuildtypes['dmpar'] = knownbuildtypes['dmpar'].upper()
 
             else:
-                self.log.error("Don't know how to figure out build type to select.")
+                raise EasyBuildError("Don't know how to figure out build type to select.")
 
         # check and fetch selected build type
         bt = self.cfg['buildtype']
 
         if not bt in knownbuildtypes.keys():
-            self.log.error("Unknown build type: '%s'. Supported build types: %s" % (bt, knownbuildtypes.keys()))
+            raise EasyBuildError("Unknown build type: '%s'. Supported build types: %s", bt, knownbuildtypes.keys())
 
         # fetch option number based on build type option and selected build type
         build_type_question = "\s*(?P<nr>[0-9]+).\s*%s\s*\(?%s\)?\s*\n" % (build_type_option, knownbuildtypes[bt])
@@ -237,11 +238,11 @@ class EB_WPS(EasyBlock):
 
             re_success = re.compile("Successful completion of %s" % cmdname)
             if not re_success.search(out):
-                self.log.error("%s.exe failed (pattern '%s' not found)?" % (cmdname, re_success.pattern))
+                raise EasyBuildError("%s.exe failed (pattern '%s' not found)?", cmdname, re_success.pattern)
 
         if self.cfg['runtest']:
             if not self.cfg['testdata']:
-                self.log.error("List of URLs for testdata not provided.")
+                raise EasyBuildError("List of URLs for testdata not provided.")
 
             wpsdir = os.path.join(self.builddir, "WPS")
 
@@ -255,7 +256,7 @@ class EB_WPS(EasyBlock):
                 for testdata in self.cfg['testdata']:
                     path = self.obtain_file(testdata)
                     if not path:
-                        self.log.error("Downloading file from %s failed?" % testdata)
+                        raise EasyBuildError("Downloading file from %s failed?", testdata)
                     testdata_paths.append(path)
 
                 # unpack data
@@ -331,7 +332,7 @@ class EB_WPS(EasyBlock):
                 os.chdir(self.builddir)
 
             except OSError, err:
-                self.log.error("Failed to run WPS test: %s" % err)
+                raise EasyBuildError("Failed to run WPS test: %s", err)
 
     # installing is done in build_step, so we can run tests
     def install_step(self):

--- a/easybuild/easyblocks/w/wrf.py
+++ b/easybuild/easyblocks/w/wrf.py
@@ -41,6 +41,7 @@ import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.netcdf import set_netcdf_env_vars, get_netcdf_module_set_cmds  # @UnresolvedImport
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM, MANDATORY
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import patch_perl_script_autoflush
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd, run_cmd_qa
@@ -91,7 +92,7 @@ class EB_WRF(EasyBlock):
                     parallel_hdf5 = False
                     break
             if not (hdf5 or parallel_hdf5):
-                self.log.error("Parallel HDF5 module not loaded?")
+                raise EasyBuildError("Parallel HDF5 module not loaded?")
             else:
                 env.setvar('PHDF5', hdf5)
         else:
@@ -106,7 +107,7 @@ class EB_WRF(EasyBlock):
 
         else:
             if os.getenv('JASPERINC') or os.getenv('JASPERLIB'):
-                self.log.error("JasPer module not loaded, but JASPERINC and/or JASPERLIB still set?")
+                raise EasyBuildError("JasPer module not loaded, but JASPERINC and/or JASPERLIB still set?")
             else:
                 self.log.info("JasPer module not loaded, assuming that's OK...")
 
@@ -126,7 +127,7 @@ class EB_WRF(EasyBlock):
             build_type_option = "x86_64 Linux, gfortran compiler with gcc"
 
         else:
-            self.log.error("Don't know how to figure out build type to select.")
+            raise EasyBuildError("Don't know how to figure out build type to select.")
 
         # fetch selected build type (and make sure it makes sense)
         known_build_types = ['serial', 'smpar', 'dmpar', 'dm+sm']
@@ -134,7 +135,7 @@ class EB_WRF(EasyBlock):
         bt = self.cfg['buildtype']
 
         if not bt in known_build_types:
-            self.log.error("Unknown build type: '%s'. Supported build types: %s" % (bt, known_build_types))
+            raise EasyBuildError("Unknown build type: '%s'. Supported build types: %s", bt, known_build_types)
 
         # fetch option number based on build type option and selected build type
         build_type_question = "\s*(?P<nr>[0-9]+).\s*%s\s*\(%s\)" % (build_type_option, bt)
@@ -223,7 +224,7 @@ class EB_WRF(EasyBlock):
                 self.testcases = os.listdir('test')
 
             except OSError, err:
-                self.log.error("Failed to determine list of test cases: %s" % err)
+                raise EasyBuildError("Failed to determine list of test cases: %s", err)
 
             # exclude 2d testcases in non-parallel WRF builds
             if self.cfg['buildtype'] in self.parallel_build_types:
@@ -273,15 +274,13 @@ class EB_WRF(EasyBlock):
                     txt = f.read()
                     f.close()
                 except IOError, err:
-                    self.log.error("Failed to read output file %s: %s" % (fn, err))
+                    raise EasyBuildError("Failed to read output file %s: %s", fn, err)
 
                 if re_success.search(txt):
                     self.log.info("Test %s ran successfully." % test)
 
                 else:
-                    self.log.error("Test %s failed, pattern '%s' not found." % (test,
-                                                                                re_success.pattern
-                                                                                ))
+                    raise EasyBuildError("Test %s failed, pattern '%s' not found.", test, re_success.pattern)
 
                 # clean up stuff that gets in the way
                 fn_prefs = ["wrfinput_", "namelist.output", "wrfout_", "rsl.out.", "rsl.error."]
@@ -330,7 +329,7 @@ class EB_WRF(EasyBlock):
                     os.chdir('..')
 
                 except OSError, err:
-                    self.log.error("An error occured when running test %s: %s" % (test, err))
+                    raise EasyBuildError("An error occured when running test %s: %s", test, err)
 
     # building/installing is done in build_step, so we can run tests
     def install_step(self):

--- a/easybuild/easyblocks/x/xcrysden.py
+++ b/easybuild/easyblocks/x/xcrysden.py
@@ -34,6 +34,7 @@ import shutil
 import sys
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root, get_software_version
 
 
@@ -50,7 +51,7 @@ class EB_XCrySDen(ConfigureMake):
         deps = ["Mesa", "Tcl", "Tk"]
         for dep in deps:
             if not get_software_root(dep):
-                self.log.error("Module for dependency %s not loaded." % dep)
+                raise EasyBuildError("Module for dependency %s not loaded.", dep)
 
         # copy template Make.sys to apply_patch
         makesys_tpl_file = os.path.join("system", "Make.sys-shared")
@@ -58,7 +59,7 @@ class EB_XCrySDen(ConfigureMake):
         try:
             shutil.copy2(makesys_tpl_file, makesys_file)
         except OSError, err:
-            self.log.error("Failed to copy %s: %s" % (makesys_tpl_file, err))
+            raise EasyBuildError("Failed to copy %s: %s", makesys_tpl_file, err)
 
         self.tclroot = get_software_root("Tcl")
         self.tclver = '.'.join(get_software_version("Tcl").split('.')[0:2])

--- a/easybuild/easyblocks/x/xmipp.py
+++ b/easybuild/easyblocks/x/xmipp.py
@@ -32,6 +32,7 @@ import os
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import mkdir, extract_file
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
@@ -58,13 +59,13 @@ class EB_Xmipp(EasyBlock):
         # check if all our dependencies are in place
         self.python_root = get_software_root('Python')
         if not self.python_root:
-            self.log.error("Python not loaded as a dependency, which is required for %s" % self.name)
+            raise EasyBuildError("Python not loaded as a dependency, which is required for %s", self.name)
         python_libdir = det_pylibdir()
         self.python_short_ver = '.'.join(get_software_version('Python').split('.')[:2])
 
         java_root = get_software_root('Java')
         if not java_root:
-            self.log.error("Java not loaded as a dependency, which is required for %s" % self.name)
+            raise EasyBuildError("Java not loaded as a dependency, which is required for %s", self.name)
 
         # extract some dependencies that we really need and can't find anywhere else
         # alglib tarball has version in name, so lets find it with a glob
@@ -90,10 +91,10 @@ class EB_Xmipp(EasyBlock):
             mpi_bindir = os.path.join(get_software_root(self.toolchain.MPI_MODULE_NAME[0]), 'bin')
 
         if not os.path.exists(numpy_inc_dir):
-            self.log.error("numpy 'include' directory %s not found" % numpy_inc_dir)
+            raise EasyBuildError("numpy 'include' directory %s not found", numpy_inc_dir)
 
         if not os.path.exists(mpi_bindir):
-            self.log.error("MPI 'bin' subdir %s does not exist" % mpi_bindir)
+            raise EasyBuildError("MPI 'bin' subdir %s does not exist", mpi_bindir)
 
         cmd = ' '.join([
             self.cfg['preconfigopts'],
@@ -144,7 +145,7 @@ class EB_Xmipp(EasyBlock):
         python_dynlib_dir = os.path.join(self.python_root, 'lib', 'python%s' % self.python_short_ver, 'lib-dynload')
 
         if not os.path.exists(python_dynlib_dir):
-            self.log.error("Python lib-dynload dir %s not found" % python_dynlib_dir)
+            raise EasyBuildError("Python lib-dynload dir %s not found", python_dynlib_dir)
 
         extra_pythonpaths = [
             os.path.join(self.cfg['start_dir'], 'protocols'),

--- a/easybuild/easyblocks/x/xml.py
+++ b/easybuild/easyblocks/x/xml.py
@@ -31,6 +31,7 @@ import os
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.rpackage import RPackage
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import get_software_root
 
 
@@ -44,7 +45,7 @@ class EB_XML(RPackage):
         zlib = get_software_root('zlib')
 
         if not zlib:
-            self.log.error("zlib module not loaded (required)")
+            raise EasyBuildError("zlib module not loaded (required)")
 
         env.setvar('LIBS', "%s -L%s" % (libs, os.path.join(zlib, 'lib')))
 

--- a/test/easyblocks/init_easyblocks.py
+++ b/test/easyblocks/init_easyblocks.py
@@ -110,11 +110,21 @@ def template_init_test(self, easyblock):
 
     self.log.debug("easyblock: %s" % easyblock)
 
-    # obtain easyblock class name using regex
+    # read easyblock Python module
     f = open(easyblock, "r")
     txt = f.read()
     f.close()
 
+    # make sure error reporting is done correctly (no more log.error, log.exception)
+    log_method_regexes = [
+        re.compile(r"log\.error\("),
+        re.compile(r"log\.exception\("),
+        re.compile(r"log\.raiseException\("),
+    ]
+    for regex in log_method_regexes:
+        self.assertFalse(regex.search(txt), "No match for '%s' in %s" % (regex.pattern, easyblock))
+
+    # obtain easyblock class name using regex
     res = class_regex.search(txt)
     if res:
         ebname = res.group(1)


### PR DESCRIPTION
matches the change in https://github.com/hpcugent/easybuild-framework/pull/1218, see also http://easybuild.readthedocs.org/en/latest/Deprecated-functionality.html#report-errors-by-raising-easybuilderror-rather-than-using-log-methods