### PR TITLE
also set $PYTHONPATH before installing Python pkgs in tmp dir in test_step

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -174,12 +174,12 @@ class PythonPackage(ExtensionEasyBlock):
                 except OSError, err:
                     raise EasyBuildError("Failed to create test install dir: %s", err)
 
-                tup = (self.cfg['preinstallopts'], testinstalldir, self.cfg['installopts'])
-                cmd = "%s python setup.py install --prefix=%s %s" % tup
-                run_cmd(cmd, log_all=True, simple=True)
-
                 run_cmd("python -c 'import sys; print(sys.path)'")  # print Python search path (debug)
                 extrapath = "export PYTHONPATH=%s:$PYTHONPATH && " % os.path.join(testinstalldir, self.pylibdir)
+
+                tup = (extrapath, self.cfg['preinstallopts'], testinstalldir, self.cfg['installopts'])
+                cmd = "%s%s python setup.py install --prefix=%s %s" % tup
+                run_cmd(cmd, log_all=True, simple=True)
 
             if self.testcmd:
                 cmd = "%s%s" % (extrapath, self.testcmd)


### PR DESCRIPTION
I'm somewhat surprised this hasn't popped up before... ran into this when test-installing an update for netcdf4-python...

```
error: bad install directory or PYTHONPATH
You are attempting to install a package to a directory that is not
on PYTHONPATH and which Python does not read ".pth" files from.
The installation directory you specified (via --install-dir, --prefix, or
the distutils default setting) was:

    /tmp/eb-5o9D62/tmpCohFbi/lib/python2.7/site-packages/                                                                                                                       
                                                                             
and your PYTHONPATH environment variable currently contains: ...
```

@wpoely86: please review?