### PR TITLE
make out-of-source build with CMake truly out-of-source

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -68,13 +68,13 @@ class CMakeMake(ConfigureMake):
 
         default_srcdir = '.'
         if self.cfg.get('separate_build_dir', False):
-            objdir = 'easybuild_obj'
+            objdir = os.path.join(self.builddir, 'easybuild_obj')
             try:
                 os.mkdir(objdir)
                 os.chdir(objdir)
             except OSError, err:
                 raise EasyBuildError("Failed to create separate build dir %s in %s: %s", objdir, os.getcwd(), err)
-            default_srcdir = '..'
+            default_srcdir = self.cfg['start_dir']
 
         if srcdir is None:
             if self.cfg.get('srcdir', None) is not None:


### PR DESCRIPTION
setting `separate_build_dir = True` in an easyconfig using the `CMakeMake` easyblock results in executing the build procedure in a subdirectory of the unpacked sources

However, some packages (like CLHEP 2.2.x) require a true out-of-source build directory.

This fix should not break other easyconfigs that are already using `separate_build_dir = True` (I'll verify that before merging).