### PR TITLE
.so files need to be in $EBROOTHADOOP/lib/native.

### DIFF
--- a/easybuild/easyblocks/h/hadoop.py
+++ b/easybuild/easyblocks/h/hadoop.py
@@ -78,7 +78,7 @@ class EB_Hadoop(Tarball):
         for native_library, lib_path in self.cfg['extra_native_libs']:
             lib_root = get_software_root(native_library)
             lib_src = os.path.join(lib_root, lib_path)
-            lib_dest = os.path.join(self.installdir, 'lib')
+            lib_dest = os.path.join(self.installdir, 'lib', 'native')
             shutil.copy2(lib_src, lib_dest)
 
     def sanity_check_step(self):

--- a/easybuild/easyblocks/h/hadoop.py
+++ b/easybuild/easyblocks/h/hadoop.py
@@ -106,7 +106,7 @@ class EB_Hadoop(Tarball):
         not_found = []
         installdir = os.path.realpath(self.installdir)
         lib_src = os.path.join([installdir, 'lib', 'native'])
-        for native_lib, lib_path  in self.cfg['extra_native_libs']:
+        for native_lib, _ in self.cfg['extra_native_libs']:
             if not re.search(r'%s: *true *%s' % (native_lib, lib_src), out):
                 not_found.append(native_lib)
         if not_found:

--- a/easybuild/easyblocks/h/hadoop.py
+++ b/easybuild/easyblocks/h/hadoop.py
@@ -105,8 +105,8 @@ class EB_Hadoop(Tarball):
 
         not_found = []
         installdir = os.path.realpath(self.installdir)
+        lib_src = os.path.join([installdir, 'lib', 'native'])
         for native_lib, lib_path  in self.cfg['extra_native_libs']:
-            lib_src = os.path.join([installdir, 'lib', 'native'])
             if not re.search(r'%s: *true *%s' % (native_lib, lib_src), out):
                 not_found.append(native_lib)
         if not_found:


### PR DESCRIPTION
native libraries in hadoop need to go in `$EBROOTHADOOP/lib/native`.

Tested.

```
$ ls $EBROOTHADOOP/Hadoop/2.5.0-cdh5.3.1-native/lib/native/
libhadoop.a	  libhadoop.so	      libhadooputils.a	libhdfs.so	  libnativetask.a   libnativetask.so.1.0.0
libhadooppipes.a  libhadoop.so.1.0.0  libhdfs.a		libhdfs.so.0.0.0  libnativetask.so  libsnappy.so
```