### PR TITLE
Fix a bug wrt os.path.join

### DIFF
--- a/easybuild/easyblocks/h/hadoop.py
+++ b/easybuild/easyblocks/h/hadoop.py
@@ -105,7 +105,7 @@ class EB_Hadoop(Tarball):
 
         not_found = []
         installdir = os.path.realpath(self.installdir)
-        lib_src = os.path.join([installdir, 'lib', 'native'])
+        lib_src = os.path.join(installdir, 'lib', 'native')
         for native_lib, _ in self.cfg['extra_native_libs']:
             if not re.search(r'%s: *true *%s' % (native_lib, lib_src), out):
                 not_found.append(native_lib)


### PR DESCRIPTION
I had a call to `os.path.join([...])` and it should have been `os.path.join(...)`. I don't know how it worked before, but it happened to work on one out of three of the clusters I tried to install this on.