### PR TITLE
revert back to not requiring Python module to be loaded in PythonPackage easyblock

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -43,7 +43,6 @@ from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import mkdir, rmtree2, which
-from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
 
 
@@ -128,9 +127,6 @@ class PythonPackage(ExtensionEasyBlock):
 
     def configure_step(self):
         """Configure Python package build."""
-        if not get_software_root('Python'):
-            raise EasyBuildError("Python module not loaded.")
-
         # prepare easyblock by determining Python site lib dir(s)
         self.set_pylibdirs()
 


### PR DESCRIPTION
This is required for easyconfig files for Python packages that are being installed without including Python as a dependency (i.e. for the system Python), like the ones using `VersionIndependentPythonPackage`.

This check was introduced in #628, but no longer needed thanks to #631.