### PR TITLE
sort glob result to choose latest version

### DIFF
--- a/easybuild/easyblocks/t/tbb.py
+++ b/easybuild/easyblocks/t/tbb.py
@@ -67,7 +67,7 @@ class EB_tbb(IntelBase):
             libglob = 'tbb/lib/intel64/cc*libc*_kernel*'
         else:
             libglob = 'tbb/lib/intel64/gcc*'
-        libs = glob.glob(libglob)
+        libs = sorted(glob.glob(libglob), key=LooseVersion)
         if len(libs):
             libdir = libs[-1]  # take the last one, should be ordered by cc get_version.
             # we're only interested in the last bit


### PR DESCRIPTION
Without the sort the installation took 4.1 instead of 4.4 on our system since the returned list of glob is not necessarily sorted by version.