### PR TITLE
Easyblock for PGI compilers

### DIFF
--- a/easybuild/easyblocks/p/pgi.py
+++ b/easybuild/easyblocks/p/pgi.py
@@ -1,0 +1,94 @@
+##
+# Copyright 2015 Bart Oldeman
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://vscentrum.be/nl/en),
+# the Hercules foundation (http://www.herculesstichting.be/in_English)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# http://github.com/hpcugent/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for installing PGI compilers, implemented as an easyblock
+
+@author: Bart Oldeman (McGill University, Calcul Quebec, Compute Canada)
+"""
+import os
+
+from easybuild.easyblocks.generic.tarball import Tarball
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.run import run_cmd
+
+class EB_pgi(Tarball):
+    """
+    Support for installing the PGI compilers
+    """
+
+    def make_module_req_guess(self):
+        """
+        A dictionary of possible directories to look for.
+        """
+        dirs = super(EB_pgi, self).make_module_req_guess()
+        prefix = os.path.join('linux86-64', self.version)
+        for key in dirs:
+            dirs[key] = [os.path.join(prefix, d) for d in dirs[key]]
+        return dirs
+
+    def sanity_check_step(self):
+        """Custom sanity check for PGI"""
+
+        prefix = os.path.join('linux86-64', self.version)
+        custom_paths = {
+                        'files': [os.path.join(prefix, "bin", "pgcc")],
+                        'dirs': [os.path.join(prefix, "bin"), os.path.join(prefix, "lib"),
+                                 os.path.join(prefix, "include"), os.path.join(prefix, "man")]
+                       }
+
+        super(EB_pgi, self).sanity_check_step(custom_paths=custom_paths)
+
+    def make_module_extra(self):
+        """Overwritten from Application to add extra txt"""
+        txt = super(EB_pgi, self).make_module_extra()
+        txt += self.module_generator.set_environment('PGI', self.installdir)
+        return txt
+
+    def install_step(self):
+        """Install by running install command."""
+
+        # make sure localrc uses GCC in PATH, not always the system GCC
+        cmd = "sed -i 's/^PATH/#PATH/' install"
+        run_cmd(cmd, log_all=True, simple=True)
+        cmd = "sed -i 's/^PATH/#PATH/' %s" % os.path.join("linux86-64", self.version,
+                                                          "bin", "makelocalrc")
+        run_cmd(cmd, log_all=True, simple=True)
+
+        cmd = 'PGI_SILENT=true PGI_ACCEPT_EULA=accept PGI_INSTALL_DIR=%s ' % self.installdir
+        cmd += 'PGI_INSTALL_NVIDIA=true PGI_INSTALL_AMD=true PGI_INSTALL_JAVA=true '
+        cmd += 'PGI_INSTALL_MANAGED=true '
+        cmd += './install'
+
+        run_cmd(cmd, log_all=True, simple=True)
+        if self.cfg['license_file']:
+            license_file = self.cfg['license_file']
+            try:
+                licfile = os.path.join(self.installdir, "license.dat")
+                os.symlink(license_file, licfile)
+            except OSError, err:
+                raise EasyBuildError("Failed to symlink %s to %s: %s", licfile, license_file, err)
+        else:
+            raise EasyBuildError("Please specify a license_file location in your easyconfig")
+

--- a/easybuild/easyblocks/p/pgi.py
+++ b/easybuild/easyblocks/p/pgi.py
@@ -39,14 +39,14 @@ from easybuild.framework.easyblock import EasyBlock
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
 
-class EB_pgi(EasyBlock):
+class EB_PGI(EasyBlock):
     """
     Support for installing the PGI compilers
     """
 
     def __init__(self, *args, **kwargs):
         """Easyblock constructor, define custom class variables specific to PGI."""
-        super(EB_pgi, self).__init__(*args, **kwargs)
+        super(EB_PGI, self).__init__(*args, **kwargs)
         if not self.cfg['license_file']:
             self.cfg['license_file'] = 'UNKNOWN'
         self.install_subdir = os.path.join('linux86-64', self.version)
@@ -97,18 +97,18 @@ class EB_pgi(EasyBlock):
                         'dirs': [os.path.join(prefix, "bin"), os.path.join(prefix, "lib"),
                                  os.path.join(prefix, "include"), os.path.join(prefix, "man")]
                        }
-        super(EB_pgi, self).sanity_check_step(custom_paths=custom_paths)
+        super(EB_PGI, self).sanity_check_step(custom_paths=custom_paths)
 
     def make_module_req_guess(self):
         """Prefix subdirectories in PGI install directory considered for environment variables defined in module file."""
-        dirs = super(EB_pgi, self).make_module_req_guess()
+        dirs = super(EB_PGI, self).make_module_req_guess()
         for key in dirs:
             dirs[key] = [os.path.join(self.install_subdir, d) for d in dirs[key]]
         return dirs
 
     def make_module_extra(self):
         """Add environment variables LM_LICENSE_FILE and PGI for license file and PGI location"""
-        txt = super(EB_pgi, self).make_module_extra()
+        txt = super(EB_PGI, self).make_module_extra()
         txt += self.module_generator.prepend_paths('LM_LICENSE_FILE', [self.cfg['license_file']], allow_abs=True)
         txt += self.module_generator.set_environment('PGI', self.installdir)
         return txt

--- a/easybuild/easyblocks/p/pgi.py
+++ b/easybuild/easyblocks/p/pgi.py
@@ -36,6 +36,7 @@ import re
 import sys
 
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.run import run_cmd
 
@@ -43,6 +44,16 @@ class EB_PGI(EasyBlock):
     """
     Support for installing the PGI compilers
     """
+
+    @staticmethod
+    def extra_options():
+        extra_vars = {
+            'install_amd': [True, "Install AMD software components", CUSTOM],
+            'install_java': [True, "Install Java JRE for graphical debugger",  CUSTOM],
+            'install_managed': [True, "Install OpenACC Unified Memory Evaluation package", CUSTOM],
+            'install_nvidia': [True, "Install CUDA Toolkit Components", CUSTOM],
+        }
+        return EasyBlock.extra_options(extra_vars)
 
     def __init__(self, *args, **kwargs):
         """Easyblock constructor, define custom class variables specific to PGI."""
@@ -69,11 +80,11 @@ class EB_PGI(EasyBlock):
 
         pgi_env_vars = {
             'PGI_ACCEPT_EULA': 'accept',
-            'PGI_INSTALL_AMD': 'true',
+            'PGI_INSTALL_AMD': str(self.cfg['install_amd']).lower(),
             'PGI_INSTALL_DIR': self.installdir,
-            'PGI_INSTALL_JAVA': 'true',
-            'PGI_INSTALL_MANAGED': 'true',
-            'PGI_INSTALL_NVIDIA': 'true',
+            'PGI_INSTALL_JAVA': str(self.cfg['install_java']).lower(),
+            'PGI_INSTALL_MANAGED': str(self.cfg['install_managed']).lower(),
+            'PGI_INSTALL_NVIDIA': str(self.cfg['install_nvidia']).lower(),
             'PGI_SILENT': 'true',
             }
         cmd = "%s ./install" % ' '.join(['%s=%s' % x for x in sorted(pgi_env_vars.items())])


### PR DESCRIPTION
This is a working easyblock to install PGI compilers. It is my first contribution so it may not be the most elegant yet. Please let me know if I missed something.

it works by untarring followed by running a sed-patched install script (to use perhaps use GCC module compilers and libraries instead of always the system compilers)

license_file is set in a matching easyconfig to which is a symlink is produced (we use the same license file for multiple PGI's, and using $PGI/license.dat looks more specific than using $LM_LICENSE_FILE).
