### PR TITLE
Update string matching

### DIFF
--- a/easybuild/easyblocks/s/suitesparse.py
+++ b/easybuild/easyblocks/s/suitesparse.py
@@ -99,7 +99,7 @@ class EB_SuiteSparse(ConfigureMake):
                     # for variables in cfgvars, substiture lines assignment 
                     # in the file, whatever they are, by assignments to the
                     # values in cfgvars
-                    line = re.sub(r"^\s*(%s\s*=\s*).*$" % var,
+                    line = re.sub(r"^\s*(%s\s*=\s*).*\n$" % var,
                                   r"\1 %s # patched by EasyBuild" % val,
                                   line)
                     if line != orig_line:


### PR DESCRIPTION
In my tests of the latest versions of suitesparse this failed because you end up with something similiar to
```
-  CFLAGS = 
-# CFLAGS = -g
+CFLAGS = 
+ -static -fPIC -unroll -O3 -xHost -ftz -fp-speculation=safe -fp-model source # patched by EasyBuild# CFLAGS = -g
```
due to the `\n` not being matched