### PR TITLE
call PythonPackage.configure_step in ConfigureMakePythonPackage.configure_step

### DIFF
--- a/easybuild/easyblocks/generic/configuremakepythonpackage.py
+++ b/easybuild/easyblocks/generic/configuremakepythonpackage.py
@@ -52,8 +52,9 @@ class ConfigureMakePythonPackage(ConfigureMake, PythonPackage):
         """Initialize with PythonPackage."""
         PythonPackage.__init__(self, *args, **kwargs)
 
-    def configure_step(self):
+    def configure_step(self, *args, **kwargs):
         """Configure build using 'python configure'."""
+        PythonPackage.configure_step(self, *args, **kwargs)
         cmd = "%s python %s" % (self.cfg['preconfigopts'], self.cfg['configopts'])
         run_cmd(cmd, log_all=True)
 


### PR DESCRIPTION
This is required to make sure that `self.all_pylibdirs` gets defined, which is used for defining `$PYTHONPATH` in the module file in `make_module_extra`.