### PR TITLE
add custom sanity check in scipy easyblock

### DIFF
--- a/easybuild/easyblocks/s/scipy.py
+++ b/easybuild/easyblocks/s/scipy.py
@@ -31,6 +31,7 @@ EasyBuild support for building and installing scipy, implemented as an easyblock
 @author: Pieter De Baets (Ghent University)
 @author: Jens Timmerman (Ghent University)
 """
+import os
 from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.fortranpythonpackage import FortranPythonPackage

--- a/easybuild/easyblocks/s/scipy.py
+++ b/easybuild/easyblocks/s/scipy.py
@@ -65,4 +65,4 @@ class EB_scipy(FortranPythonPackage):
             'dirs': [],
         }
         custom_commands = [('python', '-c "import scipy"')]
-        return (EB_scipy, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
+        return super(EB_scipy, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)

--- a/easybuild/easyblocks/s/scipy.py
+++ b/easybuild/easyblocks/s/scipy.py
@@ -57,3 +57,11 @@ class EB_scipy(FortranPythonPackage):
             if self.toolchain.comp_family() in [toolchain.GCC, toolchain.CLANGGCC]:  # @UndefinedVariable
                 self.cfg.update('preinstallopts', "unset LDFLAGS && ")
 
+    def sanity_check_step(self, *args, **kwargs):
+        """Custom sanity check for scipy."""
+        custom_paths = {
+            'files': [os.path.join(self.pylibdir, 'scipy', '__init__.py')],
+            'dirs': [],
+        }
+        custom_commands = [('python', '-c "import scipy"')]
+        return (EB_scipy, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)


### PR DESCRIPTION
required because of enabling fallback to default bin/lib sanity check paths due to hpcugent/easybuild-framework#1366