### PR TITLE
specify to always use the bfd linker for OpenFOAM, to stay away from using ld.gold

### DIFF
--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -111,7 +111,7 @@ class EB_OpenFOAM(EasyBlock):
 
         # make sure non-gold version of ld is used, since OpenFOAM requires it
         # see http://www.openfoam.org/mantisbt/view.php?id=685
-        extra_flags = '-fuse-ld=bfd'
+        extra_flags = '-Wl,-fuse-ld=bfd'
         if comp_fam == toolchain.GCC:  #@UndefinedVariable
             self.wm_compiler="Gcc"
 

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -109,6 +109,7 @@ class EB_OpenFOAM(EasyBlock):
         # compiler & compiler flags
         comp_fam = self.toolchain.comp_family()
 
+        extra_flags = ''
         if comp_fam == toolchain.GCC:  #@UndefinedVariable
             self.wm_compiler = 'Gcc'
             if get_software_version('GCC') >= LooseVersion('4.8'):

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -42,7 +42,7 @@ import easybuild.tools.toolchain as toolchain
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import adjust_permissions, mkdir
-from easybuild.tools.modules import get_software_root
+from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd, run_cmd_qa
 
 
@@ -109,17 +109,18 @@ class EB_OpenFOAM(EasyBlock):
         # compiler & compiler flags
         comp_fam = self.toolchain.comp_family()
 
-        # make sure non-gold version of ld is used, since OpenFOAM requires it
-        # see http://www.openfoam.org/mantisbt/view.php?id=685
-        extra_flags = '-Wl,-fuse-ld=bfd'
         if comp_fam == toolchain.GCC:  #@UndefinedVariable
-            self.wm_compiler="Gcc"
+            self.wm_compiler = 'Gcc'
+            if get_software_version('GCC') >= LooseVersion('4.8'):
+                # make sure non-gold version of ld is used, since OpenFOAM requires it
+                # see http://www.openfoam.org/mantisbt/view.php?id=685
+                extra_flags = '-fuse-ld=bfd'
 
         elif comp_fam == toolchain.INTELCOMP:  #@UndefinedVariable
-            self.wm_compiler="Icc"
+            self.wm_compiler = 'Icc'
 
             # make sure -no-prec-div is used with Intel compilers
-            extra_flags += ' -no-prec-div'
+            extra_flags = '-no-prec-div'
 
         else:
             raise EasyBuildError("Unknown compiler family, don't know how to set WM_COMPILER")


### PR DESCRIPTION
linking `ld.gold` with doesn't work with OpenFOAM, yields errors like:

```
.../bin/ld.gold: error: --add-needed is not supported but is required for librdmacm.so.1 in .../OpenMPI/1.8.5-GNU-4.9.2-2.25/lib/libmpi_cxx.so
```