### PR TITLE
Updated go easyblock for version 1.5. This version need the variable …

### DIFF
--- a/easybuild/easyblocks/g/go.py
+++ b/easybuild/easyblocks/g/go.py
@@ -25,6 +25,7 @@
 """
 EasyBuild support for building and installing Go, implemented as an easyblock
 
+@author: Carlos Fenoy (Roche)
 @author: Adam DeConinck (NVIDIA)
 @author: Kenneth Hoste (HPC-UGent)
 """
@@ -61,7 +62,7 @@ class EB_Go(ConfigureMake):
 
         # $GOROOT_FINAL only specifies the location of the final installation, which gets baked into the binaries
         # the installation itself is *not* done by the all.bash script, that needs to be done manually
-        cmd = "GOROOT_FINAL=%s ./all.bash" % self.installdir
+        cmd = "GOROOT_BOOTSTRAP=%s GOROOT_FINAL=%s ./all.bash" % (os.environ.get('EBROOTGO'),self.installdir)
         run_cmd(cmd, log_all=True, simple=False)
 
         try:


### PR DESCRIPTION
…GOROOT_BOOTSTRAP to point to a current Go installation