### PR TITLE
implement runtime patching of $WM_* and compiler variables for OpenFOAM

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -42,6 +42,7 @@ from easybuild.easyblocks.python import EXTS_FILTER_PYTHON_PACKAGES
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.config import build_option
 from easybuild.tools.filetools import mkdir, rmtree2, which
 from easybuild.tools.run import run_cmd
 
@@ -110,15 +111,20 @@ class PythonPackage(ExtensionEasyBlock):
 
     def set_pylibdirs(self):
         """Set Python lib directory-related class variables."""
-        # pylibdir is the 'main' Python lib directory
-        if self.pylibdir == UNKNOWN:
-            self.pylibdir = det_pylibdir()
-        self.log.debug("Python library dir: %s" % self.pylibdir)
-        # on (some) multilib systems, the platform-specific library directory for the system Python is different
-        # cfr. http://serverfault.com/a/88739/126446
-        # so, we keep a list of different Python lib directories to take into account
-        self.all_pylibdirs = nub([self.pylibdir, det_pylibdir(plat_specific=True)])
-        self.log.debug("All Python library dirs: %s" % self.all_pylibdirs)
+        if build_option('extended_dry_run'):
+            self.all_pylibdirs = ['lib/python/site-packages']
+            self.log.debug("Using fake set of Python lib dirs during dry run: %s", self.all_pylibdirs)
+
+        else:
+            # pylibdir is the 'main' Python lib directory
+            if self.pylibdir == UNKNOWN:
+                self.pylibdir = det_pylibdir()
+            self.log.debug("Python library dir: %s" % self.pylibdir)
+            # on (some) multilib systems, the platform-specific library directory for the system Python is different
+            # cfr. http://serverfault.com/a/88739/126446
+            # so, we keep a list of different Python lib directories to take into account
+            self.all_pylibdirs = nub([self.pylibdir, det_pylibdir(plat_specific=True)])
+            self.log.debug("All Python library dirs: %s" % self.all_pylibdirs)
 
     def prerun(self):
         """Prepare extension by determining Python site lib dir."""
@@ -154,14 +160,14 @@ class PythonPackage(ExtensionEasyBlock):
                 raise EasyBuildError("Creating %s failed", self.sitecfgfn)
 
         # creates log entries for python being used, for debugging
-        run_cmd("python -V")
-        run_cmd("which python")
-        run_cmd("python -c 'import sys; print(sys.executable)'")
+        run_cmd("python -V", verbose=False)
+        run_cmd("which python", verbose=False)
+        run_cmd("python -c 'import sys; print(sys.executable)'", verbose=False)
 
         # don't add user site directory to sys.path (equivalent to python -s)
         # see https://www.python.org/dev/peps/pep-0370/
-        env.setvar('PYTHONNOUSERSITE', '1')
-        run_cmd("python -c 'import sys; print(sys.path)'")
+        env.setvar('PYTHONNOUSERSITE', '1', verbose=False)
+        run_cmd("python -c 'import sys; print(sys.path)'", verbose=False)
 
     def build_step(self):
         """Build Python package using setup.py"""
@@ -217,7 +223,8 @@ class PythonPackage(ExtensionEasyBlock):
 
         # set PYTHONPATH as expected
         pythonpath = os.getenv('PYTHONPATH')
-        env.setvar('PYTHONPATH', os.pathsep.join([x for x in abs_pylibdirs + [pythonpath] if x is not None]))
+        new_pythonpath = os.pathsep.join([x for x in abs_pylibdirs + [pythonpath] if x is not None])
+        env.setvar('PYTHONPATH', new_pythonpath, verbose=False)
 
         # actually install Python package
         tup = (self.cfg['preinstallopts'], self.installdir, self.cfg['installopts'])
@@ -226,7 +233,7 @@ class PythonPackage(ExtensionEasyBlock):
 
         # restore PYTHONPATH if it was set
         if pythonpath is not None:
-            env.setvar('PYTHONPATH', pythonpath)
+            env.setvar('PYTHONPATH', pythonpath, verbose=False)
 
     def run(self, *args, **kwargs):
         """Perform the actual Python package build/installation procedure"""


### PR DESCRIPTION
This implements the fix that was proposed by @wpoely86 as an alternative to https://github.com/hpcugent/easybuild-easyconfigs/pull/1920 .

It fixes https://github.com/hpcugent/easybuild-easyconfigs/issues/1842, and also makes one of the required patch file quite a bit smaller (cfr. https://github.com/hpcugent/easybuild-easyconfigs/pull/1968).