### PR TITLE
Fix getting pylibdir in easyblock for python_meep

### DIFF
--- a/easybuild/easyblocks/p/python_meep.py
+++ b/easybuild/easyblocks/p/python_meep.py
@@ -36,7 +36,7 @@ import os
 import shutil
 import tempfile
 
-from easybuild.easyblocks.generic.pythonpackage import PythonPackage, det_pylibdir, UNKNOWN
+from easybuild.easyblocks.generic.pythonpackage import PythonPackage
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import extract_file, rmtree2
 from easybuild.tools.modules import get_software_root
@@ -56,9 +56,7 @@ class EB_python_minus_meep(PythonPackage):
         for dep in deps:
             if not get_software_root(dep):
                 raise EasyBuildError("Module for %s not loaded.", dep)
-        # prepare easyblock by determining Python site lib dir
-        if self.pylibdir == UNKNOWN:
-            self.pylibdir = det_pylibdir()
+        super(EB_python_minus_meep, self).configure_step()
 
     def build_step(self):
         """Build python-meep using available make/make-mpi script."""

--- a/easybuild/easyblocks/p/python_meep.py
+++ b/easybuild/easyblocks/p/python_meep.py
@@ -36,7 +36,7 @@ import os
 import shutil
 import tempfile
 
-from easybuild.easyblocks.generic.pythonpackage import PythonPackage
+from easybuild.easyblocks.generic.pythonpackage import PythonPackage, det_pylibdir, UNKNOWN
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import extract_file, rmtree2
 from easybuild.tools.modules import get_software_root
@@ -56,6 +56,9 @@ class EB_python_minus_meep(PythonPackage):
         for dep in deps:
             if not get_software_root(dep):
                 raise EasyBuildError("Module for %s not loaded.", dep)
+        # prepare easyblock by determining Python site lib dir
+        if self.pylibdir == UNKNOWN:
+            self.pylibdir = det_pylibdir()
 
     def build_step(self):
         """Build python-meep using available make/make-mpi script."""


### PR DESCRIPTION
python-meep package easyblock is broken. Currently, there is inherited method configure_step() that don't handle self.pylibdir variable. So during installation we have self.pylibdir 'UNKNOWN' and  numpyinc like:

```
/apps/Python/2.7.9-intel-2015b/UNKNOWN/numpy/core/include
```

instead of correct one 

```
/apps/Python/2.7.9-intel-2015b/lib/python2.7/site-packages/numpy/core/include
```

**Also, there is problem, that this easyblock count on numpy package in Python instance, not as separate module. This dependency is not mentioned in easyconfig.**