### PR TITLE
only prepend existing non-empty paths to $PYTHONPATH

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -258,6 +258,6 @@ class PythonPackage(ExtensionEasyBlock):
             fullpath = os.path.join(self.installdir, path)
             # only extend $PYTHONPATH with existing, non-empty directories
             if os.path.exists(fullpath) and os.listdir(fullpath):
-                txt += self.module_generator.prepend_paths('PYTHONPATH', fullpath)
+                txt += self.module_generator.prepend_paths('PYTHONPATH', path)
 
         return super(PythonPackage, self).make_module_extra(txt, *args, **kwargs)

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -253,6 +253,11 @@ class PythonPackage(ExtensionEasyBlock):
 
     def make_module_extra(self, *args, **kwargs):
         """Add install path to PYTHONPATH"""
+        txt = ''
+        for path in self.all_pylibdirs:
+            fullpath = os.path.join(self.installdir, path)
+            # only extend $PYTHONPATH with existing, non-empty directories
+            if os.path.exists(fullpath) and os.listdir(fullpath):
+                txt += self.module_generator.prepend_paths('PYTHONPATH', fullpath)
 
-        txt = self.module_generator.prepend_paths("PYTHONPATH", self.all_pylibdirs)
         return super(PythonPackage, self).make_module_extra(txt, *args, **kwargs)


### PR DESCRIPTION
This seems like a minor change, but it has high impact: including empty or non-existing paths in `$PYTHONPATH` can have a drastic impact on runtime (startup) performance.