### PR TITLE
use less evil 'python setup.py easy_install' instead of 'easy_install'

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -46,6 +46,7 @@ from easybuild.tools.filetools import mkdir, rmtree2, which
 from easybuild.tools.run import run_cmd
 
 
+# not 'easy_install' deliberately, to avoid that pkg installations listed in easy-install.pth get preference
 EASY_INSTALL_CMD = "python setup.py easy_install"
 UNKNOWN = 'UNKNOWN'
 

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -243,7 +243,8 @@ class PythonPackage(ExtensionEasyBlock):
         """Install Python package to a custom path using setup.py"""
 
         # mainly for debugging
-        run_cmd("%s --version" % EASY_INSTALL_CMD)
+        if self.install_cmd.startswith(EASY_INSTALL_CMD):
+            run_cmd("%s --version" % EASY_INSTALL_CMD)
 
         # create expected directories
         abs_pylibdirs = [os.path.join(self.installdir, pylibdir) for pylibdir in self.all_pylibdirs]

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -46,7 +46,7 @@ from easybuild.tools.filetools import mkdir, rmtree2, which
 from easybuild.tools.run import run_cmd
 
 
-EASY_INSTALL_CMD = 'easy_install'
+EASY_INSTALL_CMD = "python setup.py easy_install"
 UNKNOWN = 'UNKNOWN'
 
 
@@ -117,11 +117,6 @@ class PythonPackage(ExtensionEasyBlock):
             raise EasyBuildError("Installing zipped eggs requires use_easy_install = True")
 
         if self.cfg.get('use_easy_install', False):
-            if which(EASY_INSTALL_CMD) is None:
-                raise EasyBuildError("%s command not found" % EASY_INSTALL_CMD)
-
-            # mainly for debugging
-            run_cmd("%s --version" % EASY_INSTALL_CMD)
 
             self.install_cmd = "%s --no-deps" % EASY_INSTALL_CMD
             if self.cfg.get('zipped_egg', False):
@@ -246,6 +241,9 @@ class PythonPackage(ExtensionEasyBlock):
 
     def install_step(self):
         """Install Python package to a custom path using setup.py"""
+
+        # mainly for debugging
+        run_cmd("%s --version" % EASY_INSTALL_CMD)
 
         # create expected directories
         abs_pylibdirs = [os.path.join(self.installdir, pylibdir) for pylibdir in self.all_pylibdirs]


### PR DESCRIPTION
Apparently, `easy_install` is not equivalent with `python setup.py easy_install`...

When using `easy_install`, Python package installations listed in `easy-install.pth` files that are available through `$PYTHONPATH` (and probably also in `~/.local`) get preference over other installations in the Python search path, which can (and does) cause problems.

One example where this is an issue is installing `vsc-base-2.4.1.eb` on a system where an older version of vsc-base (<=v2.3) is available through `easy-install.pth`.

Using `python setup.py easy_install`, these problems do not occur.