### PR TITLE
Update numpy and SuiteSparse to use scikit-umfpack (REVIEW)

### DIFF
--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -170,12 +170,16 @@ class EB_numpy(FortranPythonPackage):
         if suitesparseroot:
             amddir = os.path.join(suitesparseroot, 'AMD')
             umfpackdir = os.path.join(suitesparseroot, 'UMFPACK')
-            extrasiteconfig += "\n[amd]\nlibrary_dirs = %s/Lib" % amddir
-            extrasiteconfig += "\ninclude_dirs = %s/Include\n" % amddir
-            extrasiteconfig += "amd_libs = amd"
-            extrasiteconfig += "\n[umfpack]\nlibrary_dirs = %s/Lib" % umfpackdir
-            extrasiteconfig += "\ninclude_dirs = %s/Include" % umfpackdir
-            extrasiteconfig += "\numfpack_libs = umfpack"
+            extrasiteconfig += '\n'.join([
+                "[amd]",
+                "library_dirs = %s" % os.path.join(amddir, 'Lib'),
+                "include_dirs = %s" % os.path.join(amddir, 'Include'),
+                "amd_libs = amd",
+                "[umfpack]",
+                "library_dirs = %s" % os.path.join(umfpackdir, 'Lib'),
+                "include_dirs = %s" % os.path.join(umfpackdir, 'Include'),
+                "umfpack_libs = umfpack",
+            ])
 
         self.sitecfg = '\n'.join([self.sitecfg, extrasiteconfig])
 

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -170,16 +170,18 @@ class EB_numpy(FortranPythonPackage):
         if suitesparseroot:
             amddir = os.path.join(suitesparseroot, 'AMD')
             umfpackdir = os.path.join(suitesparseroot, 'UMFPACK')
-            extrasiteconfig += '\n'.join([
-                "[amd]",
-                "library_dirs = %s" % os.path.join(amddir, 'Lib'),
-                "include_dirs = %s" % os.path.join(amddir, 'Include'),
-                "amd_libs = amd",
-                "[umfpack]",
-                "library_dirs = %s" % os.path.join(umfpackdir, 'Lib'),
-                "include_dirs = %s" % os.path.join(umfpackdir, 'Include'),
-                "umfpack_libs = umfpack",
-            ])
+
+            if os.path.exists(amddir) and os.path.exists(umfpackdir):
+                extrasiteconfig += '\n'.join([
+                    "[amd]",
+                    "library_dirs = %s" % os.path.join(amddir, 'Lib'),
+                    "include_dirs = %s" % os.path.join(amddir, 'Include'),
+                    "amd_libs = amd",
+                    "[umfpack]",
+                    "library_dirs = %s" % os.path.join(umfpackdir, 'Lib'),
+                    "include_dirs = %s" % os.path.join(umfpackdir, 'Include'),
+                    "umfpack_libs = umfpack",
+                ])
 
         self.sitecfg = '\n'.join([self.sitecfg, extrasiteconfig])
 

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -166,12 +166,16 @@ class EB_numpy(FortranPythonPackage):
         if fft:
             extrasiteconfig += "\n[fftw]\nlibraries = %s" % fft
 
-        if get_software_root('SUITESPARSE'):
-            suitesparseroot = get_software_root('SUITESPARSE')
+        suitesparseroot = get_software_root('SuiteSparse')
+        if suitesparseroot:
             amddir = os.path.join(suitesparseroot, 'AMD')
             umfpackdir = os.path.join(suitesparseroot, 'UMFPACK')
-            extrasiteconfig += "\n[amd]\nlibrary_dirs = %s/Lib\ninclude_dirs = %s/Include\namd_libs = amd" % (amddir, amddir)
-            extrasiteconfig += "\n[umfpack]\nlibrary_dirs = %s/Lib\ninclude_dirs = %s/Include\numfpack_libs = umfpack" % (umfpackdir, umfpackdir)
+            extrasiteconfig += "\n[amd]\nlibrary_dirs = %s/Lib" % amddir
+            extrasiteconfig += "\ninclude_dirs = %s/Include\n" % amddir
+            extrasiteconfig += "amd_libs = amd"
+            extrasiteconfig += "\n[umfpack]\nlibrary_dirs = %s/Lib" % umfpackdir
+            extrasiteconfig += "\ninclude_dirs = %s/Include" % umfpackdir
+            extrasiteconfig += "\numfpack_libs = umfpack"
 
         self.sitecfg = '\n'.join([self.sitecfg, extrasiteconfig])
 

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -171,7 +171,10 @@ class EB_numpy(FortranPythonPackage):
             amddir = os.path.join(suitesparseroot, 'AMD')
             umfpackdir = os.path.join(suitesparseroot, 'UMFPACK')
 
-            if os.path.exists(amddir) and os.path.exists(umfpackdir):
+            if not os.path.exists(amddir) or not os.path.exists(umfpackdir):
+                raise EasyBuildError("Expected SuiteSparse subdirectories are not both there: %s, %s",
+                                     amddir, umfpackdir)
+            else:
                 extrasiteconfig += '\n'.join([
                     "[amd]",
                     "library_dirs = %s" % os.path.join(amddir, 'Lib'),

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -166,6 +166,13 @@ class EB_numpy(FortranPythonPackage):
         if fft:
             extrasiteconfig += "\n[fftw]\nlibraries = %s" % fft
 
+        if get_software_root('SUITESPARSE'):
+            suitesparseroot = get_software_root('SUITESPARSE')
+            amddir = os.path.join(suitesparseroot, 'AMD')
+            umfpackdir = os.path.join(suitesparseroot, 'UMFPACK')
+            extrasiteconfig += "\n[amd]\nlibrary_dirs = %s/Lib\ninclude_dirs = %s/Include\namd_libs = amd" % (amddir, amddir)
+            extrasiteconfig += "\n[umfpack]\nlibrary_dirs = %s/Lib\ninclude_dirs = %s/Include\numfpack_libs = umfpack" % (umfpackdir, umfpackdir)
+
         self.sitecfg = '\n'.join([self.sitecfg, extrasiteconfig])
 
         self.sitecfg = self.sitecfg % {

--- a/easybuild/easyblocks/s/suitesparse.py
+++ b/easybuild/easyblocks/s/suitesparse.py
@@ -161,8 +161,13 @@ class EB_SuiteSparse(ConfigureMake):
 
     def make_module_req_guess(self):
         """Add config dir to CPATH so include file is found."""
+        """Add UMFPACK adn AMD library dirs needed for scikit-umfpack."""
         guesses = super(EB_SuiteSparse, self).make_module_req_guess()
-        guesses.update({'CPATH': [self.config_name]})
+        guesses.update({
+            'CPATH': [self.config_name],
+            'LD_LIBRARY_PATH': ['UMFPACK/Lib', 'AMD/Lib'],
+        })
+
         return guesses
 
     def sanity_check_step(self):


### PR DESCRIPTION
- update numpy's site.cfg when SuiteSparse is available
- update SuiteSparse's LD_LIBRARY_PATH to make libamd.so and libumfpack.so available