### PR TITLE
Remove custom post-install step in PDT easyblock

### DIFF
--- a/easybuild/easyblocks/p/pdt.py
+++ b/easybuild/easyblocks/p/pdt.py
@@ -69,12 +69,6 @@ class EB_PDT(ConfigureMake):
         # The PDT build is triggered by 'make install', thus skip the 'make' step
         pass
 
-    def post_install_step(self):
-        """Custom post-installation procedure for PDT."""
-        # PDT install directory includes symbolic link to system header files
-        # Try to fix permissions (part of postprocessing) then fails
-        pass
-
     def sanity_check_step(self):
         """Custom sanity check for PDT."""
         custom_paths = {


### PR DESCRIPTION
PDT creates symlinks to compiler-provided header files in its installation directory.  When using an EB-installed compiler, there is no problem.  However, when using the system compiler (e.g., by creating a corresponding EB module via `eb GCC-system.eb`), the symlinks point to somewhere in `/usr` and fixing the permissions will fail.

This custom post-install step was originally intended to suppress the fixing of permissions (which was part of the `post_install_step` at the time of writing the easyblock).  Rather than suppressing the `permissions_step` instead, we better rely on https://github.com/hpcugent/easybuild-framework/pull/1439 once it is merged.