### PR TITLE
fix OpenSSL sanity check paths: lib/engines is a directory

### DIFF
--- a/easybuild/easyblocks/o/openssl.py
+++ b/easybuild/easyblocks/o/openssl.py
@@ -61,10 +61,9 @@ class EB_OpenSSL(ConfigureMake):
             raise EasyBuildError("Failed to determine library directory.")
 
         custom_paths = {
-            'files': [os.path.join(libdir, x) for x in ['engines', 'libcrypto.a', 'libcrypto.so',
-                                                        'libcrypto.so.1.0.0', 'libssl.a',
-                                                        'libssl.so', 'libssl.so.1.0.0']] +
-                     ['bin/openssl'],
+            'files': [os.path.join(libdir, x) for x in ['libcrypto.a', 'libcrypto.so', 'libcrypto.so.1.0.0',
+                                                        'libssl.a', 'libssl.so', 'libssl.so.1.0.0']] +
+                     ['bin/openssl', os.path.join(libdir, 'engines')],
             'dirs': [],
         }
 


### PR DESCRIPTION
went undetected because of a bug in the sanity check implementation, fixed by https://github.com/hpcugent/easybuild-framework/pull/1436