### PR TITLE
take into account that $LIBS may not be defined in HPL easyblock

### DIFF
--- a/easybuild/easyblocks/h/hpl.py
+++ b/easybuild/easyblocks/h/hpl.py
@@ -101,7 +101,7 @@ class EB_HPL(ConfigureMake):
         extra_makeopts += 'HPL_OPTS="%s -DUSING_FFTW" ' % os.getenv('CPPFLAGS')
 
         # linker flags
-        extra_makeopts += 'LINKFLAGS="%s %s %s" ' % (os.getenv('CFLAGS'), os.getenv('LDFLAGS'), os.getenv('LIBS'))
+        extra_makeopts += 'LINKFLAGS="%s %s %s" ' % (os.getenv('CFLAGS'), os.getenv('LDFLAGS'), os.getenv('LIBS', ''))
 
         # C compilers flags
         extra_makeopts += "CCFLAGS='$(HPL_DEFS) %s' " % os.getenv('CFLAGS')


### PR DESCRIPTION
This is the case with Cray toolchains, for example