### PR TITLE
Fix module path extension of system compiler in HMNS setup

### DIFF
--- a/easybuild/easyblocks/generic/systemcompiler.py
+++ b/easybuild/easyblocks/generic/systemcompiler.py
@@ -137,10 +137,6 @@ class SystemCompiler(Bundle):
         """
         return {}
 
-    def post_install_step(self):
-        """Custom post install step: Do not to touch system compiler directories and files."""
-        pass
-
     def make_module_step(self, fake=False):
         """Custom module step for SystemCompiler: make 'EBROOT' and 'EBVERSION' reflect system compiler values."""
         # For module file generation: temporarly set version and installdir to system compiler values

--- a/easybuild/easyblocks/generic/systemcompiler.py
+++ b/easybuild/easyblocks/generic/systemcompiler.py
@@ -138,7 +138,10 @@ class SystemCompiler(Bundle):
         return {}
 
     def make_module_step(self, fake=False):
-        """Custom module step for SystemCompiler: make 'EBROOT' and 'EBVERSION' reflect system compiler values."""
+        """
+        Custom module step for SystemCompiler: make 'EBROOT' and 'EBVERSION' reflect actual system compiler version
+        and install path.
+        """
         # For module file generation: temporarly set version and installdir to system compiler values
         self.cfg['version'] = self.compiler_version
         self.installdir = self.compiler_prefix
@@ -153,14 +156,15 @@ class SystemCompiler(Bundle):
 
     def make_module_extend_modpath(self):
         """
-        Custom prepend-path statements for extending $MODULEPATH: use original version specified in easyconfig file.
+        Custom prepend-path statements for extending $MODULEPATH: use version specified in easyconfig file (e.g.,
+        "system") rather than the actual version (e.g., "4.8.2").
         """
-        # temporarly set switch back to original version
+        # temporarly set switch back to version specified in easyconfig file (e.g., "system")
         self.cfg['version'] = self.orig_version
 
         # Retrieve module path extensions
         res = super(SystemCompiler, self).make_module_extend_modpath()
 
-        # Reset to "real" version
+        # Reset to actual compiler version (e.g., "4.8.2")
         self.cfg['version'] = self.compiler_version
         return res

--- a/easybuild/easyblocks/generic/systemcompiler.py
+++ b/easybuild/easyblocks/generic/systemcompiler.py
@@ -150,3 +150,17 @@ class SystemCompiler(Bundle):
         self.installdir = self.orig_installdir
         self.cfg['version'] = self.orig_version
         return res
+
+    def make_module_extend_modpath(self):
+        """
+        Custom prepend-path statements for extending $MODULEPATH: use original version specified in easyconfig file.
+        """
+        # temporarly set switch back to original version
+        self.cfg['version'] = self.orig_version
+
+        # Retrieve module path extensions
+        res = super(SystemCompiler, self).make_module_extend_modpath()
+
+        # Reset to "real" version
+        self.cfg['version'] = self.compiler_version
+        return res


### PR DESCRIPTION
Running `eb GCC-system.eb` in an HMNS setup will create a module file `GCC/system`, which extends `$MODULEPATH` with `<prefix>/modules/Compiler/GCC/<gcc_version>`.  However, this may conflict with an EasyBuild-created GCC installation of the same version.  With this PR, the modulepath extension will be `<prefix>/modules/Compiler/GCC/system`.

Note: This PR also removes the custom `post_install_step` which originally was intended to skip changing permissions in system directories.  However, this was moved to a separate step.  In addition, EB only tries to modify permissions in `<prefix>`, i.e., suppressing this step is actually not needed at all.