### PR TITLE
Add mkl 11.3.1.150 support

### DIFF
--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -357,7 +357,7 @@ class EB_imkl(IntelBase):
             if self.cfg['m32']:
                 raise EasyBuildError("Sanity check for 32-bit not implemented yet for IMKL v%s (>= 10.3)", self.version)
             else:
-                mkldirs = ["bin", "mkl/bin", "mkl/bin/intel64", "mkl/lib/intel64", "mkl/include"]
+                mkldirs = ["bin", "mkl/bin", "mkl/lib/intel64", "mkl/include"]
                 libs += [lib % {'suff': suff} for lib in extralibs for suff in ['lp64', 'ilp64']]
                 mklfiles = ["mkl/lib/intel64/libmkl.so", "mkl/include/mkl.h"] + \
                            ["mkl/lib/intel64/%s" % lib for lib in libs]

--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -31,6 +31,7 @@ EasyBuild support for installing the Intel Math Kernel Library (MKL), implemente
 @author: Pieter De Baets (Ghent University)
 @author: Jens Timmerman (Ghent University)
 @author: Ward Poelmans (Ghent University)
+@author: Lumir Jasiok (IT4Innovations)
 """
 
 import itertools


### PR DESCRIPTION
Fixes the problem with wrong directory checking. There's no `mkl/bin/intel64` anymore.
