### PR TITLE
Add missing self.set_pylibdirs()

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -297,6 +297,7 @@ class PythonPackage(ExtensionEasyBlock):
     def make_module_extra(self, *args, **kwargs):
         """Add install path to PYTHONPATH"""
         txt = ''
+	self.set_pylibdirs()
         for path in self.all_pylibdirs:
             fullpath = os.path.join(self.installdir, path)
             # only extend $PYTHONPATH with existing, non-empty directories

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -297,7 +297,7 @@ class PythonPackage(ExtensionEasyBlock):
     def make_module_extra(self, *args, **kwargs):
         """Add install path to PYTHONPATH"""
         txt = ''
-	self.set_pylibdirs()
+        self.set_pylibdirs()
         for path in self.all_pylibdirs:
             fullpath = os.path.join(self.installdir, path)
             # only extend $PYTHONPATH with existing, non-empty directories


### PR DESCRIPTION
eb --module-only skips the PYTHONPATH define, resulting in a corrupt PYTHONPATH in the created module file.

This happens independent of an installed EB software, so it even happens if the software was installed before and you recreate the modulefile.