### PR TITLE
fix broken WRF easyblock under --module-only (REVIEW)

### DIFF
--- a/easybuild/easyblocks/w/wrf.py
+++ b/easybuild/easyblocks/w/wrf.py
@@ -67,20 +67,15 @@ class EB_WRF(EasyBlock):
         }
         return EasyBlock.extra_options(extra_vars)
 
-    def prepare_step(self):
-        """Prepare for building/installing."""
-        super(EB_WRF, self).prepare_step()
-
-        # define $NETCDF* for netCDF dependency (used when creating WRF module file)
-        # done as a part of prepare step so these are also defined under --module-only
-        set_netcdf_env_vars(self.log)
-
     def configure_step(self):
         """Configure build:
             - set some magic environment variables
             - run configure script
             - adjust configure.wrf file if needed
         """
+        # define $NETCDF* for netCDF dependency (used when creating WRF module file)
+        set_netcdf_env_vars(self.log)
+
         # HDF5 (optional) dependency
         hdf5 = get_software_root('HDF5')
         if hdf5:
@@ -367,7 +362,7 @@ class EB_WRF(EasyBlock):
     def make_module_extra(self):
         """Add netCDF environment variables to module file."""
         txt = super(EB_WRF, self).make_module_extra()
-        txt += self.module_generator.set_environment('NETCDF', os.getenv('NETCDF'))
-        if os.getenv('NETCDFF', None) is not None:
-            txt += self.module_generator.set_environment('NETCDFF', os.getenv('NETCDFF'))
+        for netcdf_var in ['NETCDF', 'NETCDFF']:
+            if os.getenv(netcdf_var) is not None:
+                txt += self.module_generator.set_environment(netcdf_var, os.getenv(netcdf_var))
         return txt


### PR DESCRIPTION
This undoes the changes in #746 which broke the tests are should never have been merged (they were because the PR tester wasn't configured correctly), and provides a different workaround by checking whether `$NETCDF` is defined before trying to use it.