### PR TITLE
don't hardcode 'openPBS' in GATE easyblock, use value for default_platform easyconfig parameter

### DIFF
--- a/easybuild/easyblocks/g/gate.py
+++ b/easybuild/easyblocks/g/gate.py
@@ -85,7 +85,7 @@ class EB_GATE(CMakeMake):
 
         # redefine $CFLAGS/$CXXFLAGS via options to build command ('make')
         cflags = os.getenv('CFLAGS')
-        cxxflags = "%s -DGC_DEFAULT_PLATFORM=\\'openPBS\\'" % os.getenv('CXXFLAGS')
+        cxxflags = "%s -DGC_DEFAULT_PLATFORM=\\'%s\\'" % (os.getenv('CXXFLAGS'), self.cfg['default_platform'])
         if self.toolchain.comp_family() in [toolchain.INTELCOMP]:
             # make sure GNU macros are defined by Intel compiler
             cflags += " -gcc"


### PR DESCRIPTION
cfr. https://github.com/hpcugent/easybuild-easyconfigs/issues/2156