### PR TITLE
Modified CUDA easyblock to support wrapper creation

### DIFF
--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -1,7 +1,7 @@
 ##
 # This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
 #
-# Copyright:: Copyright 2012-2015 Cyprus Institute / CaSToRC, Uni.Lu, NTUA, Ghent University, Forschungszentrum Juelich GmbH
+# Copyright:: Copyright 2012-2016 Cyprus Institute / CaSToRC, Uni.Lu, NTUA, Ghent University, Forschungszentrum Juelich GmbH
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste, Damian Alvarez
 # License::   MIT/GPL
 # $Id$

--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -1,8 +1,8 @@
 ##
 # This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
 #
-# Copyright:: Copyright 2012-2015 Cyprus Institute / CaSToRC, Uni.Lu, NTUA, Ghent University
-# Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste
+# Copyright:: Copyright 2012-2015 Cyprus Institute / CaSToRC, Uni.Lu, NTUA, Ghent University, Forschungszentrum Juelich GmbH
+# Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste, Damian Alvarez
 # License::   MIT/GPL
 # $Id$
 #
@@ -17,21 +17,42 @@ Ref: https://speakerdeck.com/ajdecon/introduction-to-the-cuda-toolkit-for-buildi
 @author: George Tsouloupas (Cyprus Institute)
 @author: Fotis Georgatos (Uni.lu)
 @author: Kenneth Hoste (Ghent University)
+@author: Damian Alvarez (Forschungszentrum Juelich)
 """
 import os
+import stat
+
 from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.binary import Binary
-from easybuild.tools.filetools import patch_perl_script_autoflush
+from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.filetools import adjust_permissions, patch_perl_script_autoflush, write_file
 from easybuild.tools.run import run_cmd, run_cmd_qa
 from easybuild.tools.systemtools import get_shared_lib_ext
 
+# Wrapper script definition
+wrapper = """#!/bin/sh
+echo "$@" | grep -e '-ccbin' -e '--compiler-bindir' > /dev/null
+if [ $? -eq 0 ];
+then
+        echo "ERROR: do not set -ccbin or --compiler-bindir when using the `basename $0` wrapper"
+else
+        nvcc -ccbin=%s "$@"
+        exit $?
+fi """
 
 class EB_CUDA(Binary):
     """
     Support for installing CUDA.
     """
 
+    @staticmethod
+    def extra_options():
+        extra_vars = {
+            'host_compilers': [[], "Host compilers for which a wrapper will be generated", CUSTOM]
+        }
+        return Binary.extra_options(extra_vars)
+ 
     def extract_step(self):
         """Extract installer to have more control, e.g. options, patching Perl scripts, etc."""
         execpath = self.src[0]['path']
@@ -78,6 +99,16 @@ class EB_CUDA(Binary):
     
         #overriding maxhits default value to 300 (300s wait for nothing to change in the output without seeing a known question)
         run_cmd_qa(cmd, qanda, std_qa=stdqa, no_qa=noqanda, log_all=True, simple=True, maxhits=300)
+
+    def post_install_step(self):
+        def create_wrapper(wrapper_name,wrapper_comp):
+	    wrapper_f = "%s/bin/%s" % (self.installdir, wrapper_name)
+	    write_file(wrapper_f, wrapper % wrapper_comp)
+            adjust_permissions(wrapper_f, stat.S_IXUSR|stat.S_IRUSR|stat.S_IXGRP|stat.S_IRGRP|stat.S_IXOTH|stat.S_IROTH)
+
+	# Prepare wrappers to handle a default host compiler other than g++
+        for comp in self.cfg['host_compilers']:
+            create_wrapper('nvcc_%s' % comp,'%s' % comp)
 
     def sanity_check_step(self):
         """Custom sanity check for CUDA."""

--- a/easybuild/easyblocks/c/cuda.py
+++ b/easybuild/easyblocks/c/cuda.py
@@ -116,3 +116,12 @@ class EB_CUDA(Binary):
         })
 
         return guesses
+    
+    def make_module_extra(self):
+        """Specify CUDA_HOME """
+
+        txt = super(EB_CUDA, self).make_module_extra()
+
+        txt += self.module_generator.set_environment('CUDA_HOME', self.installdir)
+
+        return txt


### PR DESCRIPTION
This PR modifies the CUDA easyblock to support the optional creation of nvcc wrappers. It adds two extra boolean options for easyconfigs: generate_intel_wrapper and generate_gcc_wrapper. The first one will create a wrapper invcc. The second a wrapper called gnvcc.

This allows to simply tell users "Use invcc to have icpc as a host compiler".

This is a convenience fix that doesn't modify the default behaviour or installation.

It will be followed by another PR in the easyconfigs repo, with an example for iccifort+CUDA.

UPDATE: The naming of the wrappers and how they are created has changed significantly. Take a look at the development of the PR.