### PR TITLE
[bugfix] fix numpy sanity check command + cleaner output under -x

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -230,12 +230,12 @@ class PythonPackage(ExtensionEasyBlock):
                 except OSError, err:
                     raise EasyBuildError("Failed to create test install dir: %s", err)
 
-                run_cmd("python -c 'import sys; print(sys.path)'")  # print Python search path (debug)
+                run_cmd("python -c 'import sys; print(sys.path)'", verbose=False)  # print Python search path (debug)
                 abs_pylibdirs = [os.path.join(testinstalldir, pylibdir) for pylibdir in self.all_pylibdirs]
                 extrapath = "export PYTHONPATH=%s &&" % os.pathsep.join(abs_pylibdirs + ['$PYTHONPATH'])
 
                 cmd = self.compose_install_command(testinstalldir, extrapath=extrapath)
-                run_cmd(cmd, log_all=True, simple=True)
+                run_cmd(cmd, log_all=True, simple=True, verbose=False)
 
             if self.testcmd:
                 cmd = "%s%s" % (extrapath, self.testcmd)

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -231,6 +231,8 @@ class EB_numpy(FortranPythonPackage):
             elif self.dry_run:
                 # use fake value during dry run
                 time_msec = 123
+                self.log.warning("Using fake value for time required for %dx%d matrix dot product under dry run: %s",
+                                 size, size, time_msec)
             else:
                 raise EasyBuildError("Failed to determine time for numpy.dot test run.")
 
@@ -260,7 +262,7 @@ class EB_numpy(FortranPythonPackage):
         if LooseVersion(self.version) >= LooseVersion("1.10"):
             # if blas_dot symbol is not there, numpy isn't properly linked against a BLAS library
             multiarray_so = os.path.join(self.installdir, self.pylibdir, 'numpy', 'core', 'multiarray.so')
-            custom_commands.append("nm %s | grep blas_dot" % self.installdir(multiarray_so)
+            custom_commands.append("nm %s | grep blas_dot" % multiarray_so)
         else:
             # _dotblas is required for decent performance of numpy.dot(), but only there in numpy 1.9.x and older
             custom_commands.append (('python', '-c "import numpy.core._dotblas"'))

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -198,7 +198,7 @@ class EB_numpy(FortranPythonPackage):
         # temporarily install numpy, it doesn't alow to be used straight from the source dir
         tmpdir = tempfile.mkdtemp()
         cmd = "python setup.py install --prefix=%s %s" % (tmpdir, self.installopts)
-        run_cmd(cmd, log_all=True, simple=True)
+        run_cmd(cmd, log_all=True, simple=True, verbose=False)
 
         try:
             pwd = os.getcwd()
@@ -228,7 +228,10 @@ class EB_numpy(FortranPythonPackage):
             res = sec_re.search(out)
             if res:
                 time_msec = 1000 * float(res.group('time'))
-            elif not self.dry_run:
+            elif self.dry_run:
+                # use fake value during dry run
+                time_msec = 123
+            else:
                 raise EasyBuildError("Failed to determine time for numpy.dot test run.")
 
         # make sure we observe decent performance
@@ -256,8 +259,8 @@ class EB_numpy(FortranPythonPackage):
         ]
         if LooseVersion(self.version) >= LooseVersion("1.10"):
             # if blas_dot symbol is not there, numpy isn't properly linked against a BLAS library
-            multiarray_so = os.path.join(self.pylibdir, 'numpy', 'core', 'multiarray.so')
-            custom_commands.append("nm %s | grep blas_dot" % multiarray_so)
+            multiarray_so = os.path.join(self.installdir, self.pylibdir, 'numpy', 'core', 'multiarray.so')
+            custom_commands.append("nm %s | grep blas_dot" % self.installdir(multiarray_so)
         else:
             # _dotblas is required for decent performance of numpy.dot(), but only there in numpy 1.9.x and older
             custom_commands.append (('python', '-c "import numpy.core._dotblas"'))

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -262,7 +262,7 @@ class EB_numpy(FortranPythonPackage):
         if LooseVersion(self.version) >= LooseVersion("1.10"):
             # if blas_dot symbol is not there, numpy isn't properly linked against a BLAS library
             multiarray_so = os.path.join(self.installdir, self.pylibdir, 'numpy', 'core', 'multiarray.so')
-            custom_commands.append("nm %s | grep blas_dot" % multiarray_so)
+            custom_commands.append(("nm %s | grep blas_dot" % multiarray_so, ''))
         else:
             # _dotblas is required for decent performance of numpy.dot(), but only there in numpy 1.9.x and older
             custom_commands.append (('python', '-c "import numpy.core._dotblas"'))


### PR DESCRIPTION
We need to use the full path to `multiarray.so` to avoid problems with the sanity check.
