### PR TITLE
use generic way of checking BLAS linkage for recent numpy versions

### DIFF
--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -262,10 +262,11 @@ class EB_numpy(FortranPythonPackage):
         if LooseVersion(self.version) >= LooseVersion("1.10"):
             # generic check to see whether numpy v1.10.x and up was built against a CBLAS-enabled library
             # cfr. https://github.com/numpy/numpy/issues/6675#issuecomment-162601149
-            blas_check_pytxt = '\n'.join([
-                "import sys; import numpy;",
-                "blas_ok = \\'HAVE_CBLAS\\' in dict(numpy.__config__.blas_opt_info[\\'define_macros\\']);",
-                "sys.exit((1, 0)[blas_ok]);",
+            blas_check_pytxt = '; '.join([
+                "import sys",
+                "import numpy",
+                "blas_ok = \\'HAVE_CBLAS\\' in dict(numpy.__config__.blas_opt_info[\\'define_macros\\'])",
+                "sys.exit((1, 0)[blas_ok])",
             ])
             custom_commands.append(('python', "-c '%s'" % blas_check_pytxt))
         else:

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -265,7 +265,7 @@ class EB_numpy(FortranPythonPackage):
             blas_check_pytxt = '\n'.join([
                 "import sys; import numpy;",
                 "blas_ok = 'HAVE_CBLAS' in dict(numpy.__config__.blas_opt_info['define_macros']);",
-                "sys.exit((1, 0)[blas_ok];",
+                "sys.exit((1, 0)[blas_ok]);",
             ])
             custom_commands.append(('python', "-c '%s'" % blas_check_pytxt))
             if get_software_root("imkl"):

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -260,9 +260,18 @@ class EB_numpy(FortranPythonPackage):
             ('python', '-c "import numpy"'),
         ]
         if LooseVersion(self.version) >= LooseVersion("1.10"):
-            # if blas_dot symbol is not there, numpy isn't properly linked against a BLAS library
-            multiarray_so = os.path.join(self.installdir, self.pylibdir, 'numpy', 'core', 'multiarray.so')
-            custom_commands.append(("nm %s | grep blas_dot" % multiarray_so, ''))
+            # generic check to see whether numpy v1.10.x and up was built against a CBLAS-enabled library
+            # cfr. https://github.com/numpy/numpy/issues/6675#issuecomment-162601149
+            blas_check_pytxt = '\n'.join([
+                "import sys; import numpy;",
+                "blas_ok = 'HAVE_CBLAS' in dict(numpy.__config__.blas_opt_info['define_macros']);",
+                "sys.exit((1, 0)[blas_ok];",
+            ])
+            custom_commands.append(('python', "-c '%s'" % blas_check_pytxt))
+            if get_software_root("imkl"):
+                # if blas_dot symbol is not there, numpy isn't properly linked against Intel MKL
+                multiarray_so = os.path.join(self.installdir, self.pylibdir, 'numpy', 'core', 'multiarray.so')
+                custom_commands.append(("nm %s | grep blas_dot" % multiarray_so, ''))
         else:
             # _dotblas is required for decent performance of numpy.dot(), but only there in numpy 1.9.x and older
             custom_commands.append (('python', '-c "import numpy.core._dotblas"'))

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -264,7 +264,7 @@ class EB_numpy(FortranPythonPackage):
             # cfr. https://github.com/numpy/numpy/issues/6675#issuecomment-162601149
             blas_check_pytxt = '\n'.join([
                 "import sys; import numpy;",
-                "blas_ok = 'HAVE_CBLAS' in dict(numpy.__config__.blas_opt_info['define_macros']);",
+                "blas_ok = \'HAVE_CBLAS\' in dict(numpy.__config__.blas_opt_info[\'define_macros\']);",
                 "sys.exit((1, 0)[blas_ok]);",
             ])
             custom_commands.append(('python', "-c '%s'" % blas_check_pytxt))

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -264,7 +264,7 @@ class EB_numpy(FortranPythonPackage):
             # cfr. https://github.com/numpy/numpy/issues/6675#issuecomment-162601149
             blas_check_pytxt = '\n'.join([
                 "import sys; import numpy;",
-                "blas_ok = \'HAVE_CBLAS\' in dict(numpy.__config__.blas_opt_info[\'define_macros\']);",
+                "blas_ok = \\'HAVE_CBLAS\' in dict(numpy.__config__.blas_opt_info[\\'define_macros\\']);",
                 "sys.exit((1, 0)[blas_ok]);",
             ])
             custom_commands.append(('python', "-c '%s'" % blas_check_pytxt))

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -265,10 +265,10 @@ class EB_numpy(FortranPythonPackage):
             blas_check_pytxt = '; '.join([
                 "import sys",
                 "import numpy",
-                "blas_ok = \\'HAVE_CBLAS\\' in dict(numpy.__config__.blas_opt_info[\\'define_macros\\'])",
+                "blas_ok = 'HAVE_CBLAS' in dict(numpy.__config__.blas_opt_info['define_macros'])",
                 "sys.exit((1, 0)[blas_ok])",
             ])
-            custom_commands.append(('python', "-c '%s'" % blas_check_pytxt))
+            custom_commands.append(('python', '-c "%s"' % blas_check_pytxt))
         else:
             # _dotblas is required for decent performance of numpy.dot(), but only there in numpy 1.9.x and older
             custom_commands.append (('python', '-c "import numpy.core._dotblas"'))

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -264,7 +264,7 @@ class EB_numpy(FortranPythonPackage):
             # cfr. https://github.com/numpy/numpy/issues/6675#issuecomment-162601149
             blas_check_pytxt = '\n'.join([
                 "import sys; import numpy;",
-                "blas_ok = \\'HAVE_CBLAS\' in dict(numpy.__config__.blas_opt_info[\\'define_macros\\']);",
+                "blas_ok = \\'HAVE_CBLAS\\' in dict(numpy.__config__.blas_opt_info[\\'define_macros\\']);",
                 "sys.exit((1, 0)[blas_ok]);",
             ])
             custom_commands.append(('python', "-c '%s'" % blas_check_pytxt))

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -268,10 +268,6 @@ class EB_numpy(FortranPythonPackage):
                 "sys.exit((1, 0)[blas_ok]);",
             ])
             custom_commands.append(('python', "-c '%s'" % blas_check_pytxt))
-            if get_software_root("imkl"):
-                # if blas_dot symbol is not there, numpy isn't properly linked against Intel MKL
-                multiarray_so = os.path.join(self.installdir, self.pylibdir, 'numpy', 'core', 'multiarray.so')
-                custom_commands.append(("nm %s | grep blas_dot" % multiarray_so, ''))
         else:
             # _dotblas is required for decent performance of numpy.dot(), but only there in numpy 1.9.x and older
             custom_commands.append (('python', '-c "import numpy.core._dotblas"'))


### PR DESCRIPTION
implement generic way of checking BLAS linkage in numpy

check for `blas_dot` symbol (cfr. #757) doesn't always work, apparently (seems like it's not there when optimising more aggressively (-O3 vs -O2), or whne `-fPIC` is used)

cfr. https://github.com/numpy/numpy/issues/6675#issuecomment-162601149

cc @gppezzi