### PR TITLE
fix for vsc-base being picked from OS during EasyBuild install (WIP)

### DIFF
--- a/easybuild/easyblocks/e/easybuildmeta.py
+++ b/easybuild/easyblocks/e/easybuildmeta.py
@@ -107,7 +107,8 @@ class EB_EasyBuildMeta(PythonPackage):
         easy_install_pth = os.path.join(self.installdir, det_pylibdir(), 'easy-install.pth')
         if os.path.exists(easy_install_pth):
             easy_install_pth_txt = read_file(easy_install_pth)
-            for pkg in self.easybuild_pkgs:
+            #for pkg in self.easybuild_pkgs:
+            for pkg in [pkg for pkg in self.easybuild_pkgs if 'vsc-base' != pkg]:
                 if pkg == 'vsc-base':
                     # don't include strict version check for vsc-base
                     pkg_regex = re.compile(r"^\./%s" % pkg.replace('-', '_'), re.M)


### PR DESCRIPTION
If vsc-base is also available on the OS, it may be picked up during the EasyBuild installation, causing the (strict) sanity check to fail:

```
$ eb EasyBuild-2.4.0.eb
...
== sanity checking...
== FAILED: Installation ended unsuccessfully (build directory: /tmp/vsc40003/easybuild/EasyBuild/2.4.0/dummy-dummy): build failed (first 300 chars): Failed to find pattern '^\./vsc_base' in /gpfs/scratch/apps/develop/software/EasyBuild/2.4.0/lib/python2.6/site-packages/easy-install.pth: import sys; sys.__plen = len(sys.path)
./easybuild_framework-2.4.0-py2.6.egg
./easybuild_easyblocks-2.4.0-py2.6.egg
./easybuild_easyconfigs-2.4.0-py2.6.egg
impor
```

Although `vsc-base` *is* being installed in the target installation prefix, it is not listed in the `easy_install.pth` file, because a more recent version is found on the OS.

```
$ ls /gpfs/scratch/apps/develop/software/EasyBuild/2.4.0/lib/python2.6/site-packages/    
easy-install.pth		      easybuild_easyconfigs-2.4.0-py2.6.egg  setuptools.pth  site.pyc
easybuild_easyblocks-2.4.0-py2.6.egg  easybuild_framework-2.4.0-py2.6.egg    site.py	     vsc_base-2.2.4-py2.6.egg
```

```
$ cat /gpfs/scratch/apps/develop/software/EasyBuild/2.4.0/lib/python2.6/site-packages/easy-install.pth 
import sys; sys.__plen = len(sys.path)
./easybuild_framework-2.4.0-py2.6.egg
./easybuild_easyblocks-2.4.0-py2.6.egg
./easybuild_easyconfigs-2.4.0-py2.6.egg
import sys; new=sys.path[sys.__plen:]; del sys.path[sys.__plen:]; p=getattr(sys,'__egginsert',0); sys.path[p:p]=new; sys.__egginsert = p+len(new)
```

From the `python setup.py install` output for `easybuild-framework`:

```
Processing dependencies for easybuild-framework==2.4.0
Searching for vsc-base==2.4.10
Best match: vsc-base 2.4.10
Removing vsc-base 2.2.4 from easy-install.pth file
Adding vsc-base 2.4.10 to easy-install.pth file
```

cc @wpoely86 