### PR TITLE
Libxml2 when not available from OS

### DIFF
--- a/easybuild/easyblocks/l/libxml2.py
+++ b/easybuild/easyblocks/l/libxml2.py
@@ -27,7 +27,7 @@ EasyBuild support for building and installing libxml2 with python bindings,
 implemented as an easyblock.
 
 @author: Jens Timmerman (Ghent University)
-@author: Alan O'Cais (Juelich Supercomputing Centre)
+@author: Alan O'Cais (Juelich Supercomputing 'entre)
 """
 import os
 
@@ -55,7 +55,7 @@ class EB_libxml2(ConfigureMake, PythonPackage):
         if not get_software_root('Python'):
             raise EasyBuildError("Python module not loaded")
         # We will do the python bindings ourselves so force them off
-        self.cfg.update('configopts', `--without-python`)
+        self.cfg.update('configopts', '--without-python')
         ConfigureMake.configure_step(self)
 
     def build_step(self):

--- a/easybuild/easyblocks/l/libxml2.py
+++ b/easybuild/easyblocks/l/libxml2.py
@@ -27,6 +27,7 @@ EasyBuild support for building and installing libxml2 with python bindings,
 implemented as an easyblock.
 
 @author: Jens Timmerman (Ghent University)
+@author: Alan O'Cais (Juelich Supercomputing Centre)
 """
 import os
 

--- a/easybuild/easyblocks/l/libxml2.py
+++ b/easybuild/easyblocks/l/libxml2.py
@@ -76,7 +76,7 @@ class EB_libxml2(ConfigureMake, PythonPackage):
             # and that only exists after installation
             os.chdir('python')
             PythonPackage.configure_step(self)
-            # set cflags to point to include folder
+            # set cflags to point to include folder for the compilation step to succeed
             env.setvar('CFLAGS', "-I../include")
             PythonPackage.build_step(self)
             PythonPackage.install_step(self)
@@ -94,7 +94,9 @@ class EB_libxml2(ConfigureMake, PythonPackage):
         """Custom sanity check for libxml2"""
 
         custom_paths = {
-                        'files':["lib/libxml2.a", "lib/libxml2.so"],
+                        'files':["lib/libxml2.a", "lib/libxml2.so"] +
+                                [os.path.join(self.pylibdir, x)
+                                 for x in ['libxml2mod.so', 'libxml2.py', 'drv_libxml2.py']],
                         'dirs':["bin", self.pylibdir, "include/libxml2/libxml"],
                        }
 


### PR DESCRIPTION
This only worked initially because setup.py found the libxml headers from the system. When these are not available the installation fails.

Also need to explicitly tell the configure not to build the python bindings itself (otherwise it will try to install them as an extension to the python it finds and you might not have permission there...and it's also not what you want).