### PR TITLE
add support for specifying altroot/altversion in Bundle easyblock

### DIFF
--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -33,15 +33,37 @@ EasyBuild support for installing a bundle of modules, implemented as a generic e
 """
 
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.modules import get_software_root, get_software_version
 
 
 class Bundle(EasyBlock):
     """
     Bundle of modules: only generate module files, nothing to build/install
     """
+
+    @staticmethod
+    def extra_options():
+        extra_vars = {
+            'altroot': [None, "Software name of dependency to use to define $EBROOT for this bundle", CUSTOM],
+            'altversion': [None, "Software name of dependency to use to define $EBVERSION for this bundle", CUSTOM],
+        }
+        return EasyBlock.extra_options(extra_vars)
+
+    def __init__(self, *args, **kwargs):
+        """Initialize easyblock."""
+        super(Bundle, self).__init__(*args, **kwargs)
+        self.altroot, self.altversion = None, None
+
     def configure_step(self):
-        """Do nothing."""
-        pass
+        """Collect altroot/altversion info."""
+        # pick up altroot/altversion, if they are defined
+        self.altroot = self.cfg['altroot']
+        if self.altroot:
+            self.altroot = get_software_root(self.altroot)
+        self.altversion = self.cfg['altversion']
+        if self.altversion:
+            self.altversion = get_software_version(self.altversion)
 
     def build_step(self):
         """Do nothing."""
@@ -50,6 +72,10 @@ class Bundle(EasyBlock):
     def install_step(self):
         """Do nothing."""
         pass
+
+    def make_module_extra(self):
+        """Set extra stuff in module file, e.g. $EBROOT*, $EBVERSION*, etc."""
+        return super(Bundle, self).make_module_extra(altroot=self.altroot, altversion=self.altversion)
 
     def sanity_check_step(self, *args, **kwargs):
         """

--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -53,16 +53,17 @@ class Bundle(EasyBlock):
     def __init__(self, *args, **kwargs):
         """Initialize easyblock."""
         super(Bundle, self).__init__(*args, **kwargs)
-        self.altroot, self.altversion = None, None
+        self.altroot = None
+        self.altversion = None
 
     def configure_step(self):
         """Collect altroot/altversion info."""
         # pick up altroot/altversion, if they are defined
-        self.altroot = self.cfg['altroot']
-        if self.altroot:
+        self.altroot = None
+        if self.cfg['altroot']:
             self.altroot = get_software_root(self.altroot)
-        self.altversion = self.cfg['altversion']
-        if self.altversion:
+        self.altversion = None
+        if self.cfg['altversion']:
             self.altversion = get_software_version(self.altversion)
 
     def build_step(self):

--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -61,10 +61,10 @@ class Bundle(EasyBlock):
         # pick up altroot/altversion, if they are defined
         self.altroot = None
         if self.cfg['altroot']:
-            self.altroot = get_software_root(self.altroot)
+            self.altroot = get_software_root(self.cfg['altroot'])
         self.altversion = None
         if self.cfg['altversion']:
-            self.altversion = get_software_version(self.altversion)
+            self.altversion = get_software_version(self.cfg['altversion'])
 
     def build_step(self):
         """Do nothing."""


### PR DESCRIPTION
depends on ~~https://github.com/hpcugent/easybuild-framework/pull/1508~~, required for https://github.com/hpcugent/easybuild-easyconfigs/pull/2214