### PR TITLE
don't set $GXX_ROOT, it breaks icpc finding C++ header files

### DIFF
--- a/easybuild/easyblocks/i/icc.py
+++ b/easybuild/easyblocks/i/icc.py
@@ -155,22 +155,3 @@ class EB_icc(IntelBase):
                     dirmap[k].append(v2)
 
         return dirmap
-
-    def make_module_extra(self):
-        """Custom variable definitions in module file: $GXX_ROOT."""
-        txt = super(EB_icc, self).make_module_extra()
-
-        # in case people are using unusual locales need to set GXX_ROOT, see
-        # https://software.intel.com/en-us/articles/
-        # intel-fortran-compiler-for-linux-ifort-error-could-not-find-directory-in-which-g-resides
-        cmd = "g++ --print-search-dirs"
-        out, _ = run_cmd(cmd, log_all=True, simple=False, force_in_dry_run=True)
-        install_line_parts = out.strip().split('\n')[0].split(':')
-        if len(install_line_parts) == 2 and install_line_parts[0] == 'install':
-            gxxroot = install_line_parts[1].strip()
-        else:
-            raise EasyBuildError("Unexpected output from %s: %s", cmd, out)
-
-        txt += self.module_generator.set_environment('GXX_ROOT', gxxroot)
-
-        return txt


### PR DESCRIPTION
(replaces #774)

this undoes the changes made in #747 and #771, because they break `icpc`:

```
bash-4.1$ icpc --version
icpc (ICC) 15.0.3 20150407
Copyright (C) 1985-2015 Intel Corporation.  All rights reserved.

bash-4.1$ echo $GXX_ROOT
/user/scratchdelcatty/gent/gvo000/gvo00002/vsc40023/easybuild_REGTEST/SL6/sandybridge/software/GCC/4.9.3-binutils-2.25/bin/../lib/gcc/x86_64-unknown-linux-gnu/4.9.3/
bash-4.1$ echo $GXX_INCLUDE

bash-4.1$ icpc hello.cpp
icpc: error #10001: could not find directory in which the set of libstdc++ include files resides
bash-4.1$ 
bash-4.1$ 
```

it probably requires getting `$GXX_INCLUDE` right too, but that doesn't seem to be trivial...

```
bash-4.1$ export GXX_INCLUDE=/user/scratchdelcatty/gent/gvo000/gvo00002/vsc40023/easybuild_REGTEST/SL6/sandybridge/software/GCC/4.9.3-binutils-2.25/include/c++/4.9.3
bash-4.1$ icpc hello.cpp
In file included from hello.cpp(1):
/user/scratchdelcatty/gent/gvo000/gvo00002/vsc40023/easybuild_REGTEST/SL6/sandybridge/software/GCC/4.9.3-binutils-2.25/include/c++/4.9.3/iostream(38): catastrophic error: cannot open source file "bits/c++config.h"
  #include <bits/c++config.h>
                             ^

compilation aborted for hello.cpp (code 4)
```

cc @ocaisa