### PR TITLE
[bugfix] fix determine lib subdir for recent tbb versions

### DIFF
--- a/easybuild/easyblocks/t/tbb.py
+++ b/easybuild/easyblocks/t/tbb.py
@@ -120,7 +120,7 @@ class EB_tbb(IntelBase):
             else:
                 raise EasyBuildError("No libs found using %s in %s", libglob, self.installdir)
         else:
-            libdir = 'tbb/lib/intel64/%s' % get_tbb_gccprefix()
+            libdir = get_tbb_gccprefix()
 
         self.libpath = os.path.join('tbb', 'libs', 'intel64', libdir)
         self.log.debug("self.libpath: %s" % self.libpath)


### PR DESCRIPTION
fix for small bug that was introduced in #756, which breaks the sanity check for tbb 4.3.x and 4.4.x