### PR TITLE
removing shared objects from newer versions of bamtools

### DIFF
--- a/easybuild/easyblocks/b/bamtools.py
+++ b/easybuild/easyblocks/b/bamtools.py
@@ -77,8 +77,8 @@ class EB_BamTools(MakeCp, CMakeMake):
                 "lib/libjsoncpp.%s" % sharedlib_ext
             ])
         else:
-            custom_paths['files'] += [
+            custom_paths['files'].extend([
                 "lib/libbamtools-utils.a",
                 "lib/libjsoncpp.a"
-            ]
+            ])
         super(EB_BamTools, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/b/bamtools.py
+++ b/easybuild/easyblocks/b/bamtools.py
@@ -72,10 +72,10 @@ class EB_BamTools(MakeCp, CMakeMake):
         if LooseVersion(self.version) < LooseVersion('2.3.0'):
             # Buid environment changed:
             # https://github.com/pezmaster31/bamtools/commit/9cfa70bfe9cdf1b6adc06beb88246b45fdd6250a
-            custom_paths['files'] += [
+            custom_paths['files'].extend([
                 "lib/libbamtools-utils.%s" % sharedlib_ext,
                 "lib/libjsoncpp.%s" % sharedlib_ext
-            ]
+            ])
         else:
             custom_paths['files'] += [
                 "lib/libbamtools-utils.a",

--- a/easybuild/easyblocks/b/bamtools.py
+++ b/easybuild/easyblocks/b/bamtools.py
@@ -63,7 +63,7 @@ class EB_BamTools(MakeCp, CMakeMake):
                       "lib/libbamtools.%s" % sharedlib_ext],
             'dirs': ["include/api", "docs"]
         }
-        if LooseVersion(self.version) <= LooseVersion('2.3.0'):
+        if LooseVersion(self.version) < LooseVersion('2.3.0'):
             custom_paths['files'] += [
                 "lib/libbamtools-utils.%s" % sharedlib_ext,
                 "lib/libjsoncpp.%s" % sharedlib_ext]

--- a/easybuild/easyblocks/b/bamtools.py
+++ b/easybuild/easyblocks/b/bamtools.py
@@ -62,18 +62,23 @@ class EB_BamTools(MakeCp, CMakeMake):
                 "bin/bamtools",
                 "include/shared/bamtools_global.h",
                 "lib/libbamtools.a",
-                "lib/libbamtools.%s" % sharedlib_ext],
+                "lib/libbamtools.%s" % sharedlib_ext
+            ],
             'dirs': [
                 "include/api",
-                "docs"]
+                "docs"
+            ]
         }
         if LooseVersion(self.version) < LooseVersion('2.3.0'):
-            #Buid environment changed https://github.com/pezmaster31/bamtools/commit/9cfa70bfe9cdf1b6adc06beb88246b45fdd6250a
+            # Buid environment changed:
+            # https://github.com/pezmaster31/bamtools/commit/9cfa70bfe9cdf1b6adc06beb88246b45fdd6250a
             custom_paths['files'] += [
                 "lib/libbamtools-utils.%s" % sharedlib_ext,
-                "lib/libjsoncpp.%s" % sharedlib_ext]
+                "lib/libjsoncpp.%s" % sharedlib_ext
+            ]
         else:
             custom_paths['files'] += [
                 "lib/libbamtools-utils.a",
-                "lib/libjsoncpp.a"]
+                "lib/libjsoncpp.a"
+            ]
         super(EB_BamTools, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/b/bamtools.py
+++ b/easybuild/easyblocks/b/bamtools.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2015 The Cyprus Institute 
+# Copyright 2009-2015 The Cyprus Institute
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
@@ -29,7 +29,7 @@ EasyBuild support for BamTools, implemented as an easyblock
 @author: Kenneth Hoste (Ghent University)
 """
 import os
-
+from distutils.version import LooseVersion
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.easyblocks.generic.makecp import MakeCp
 from easybuild.tools.build_log import EasyBuildError
@@ -57,11 +57,15 @@ class EB_BamTools(MakeCp, CMakeMake):
 
         sharedlib_ext = get_shared_lib_ext()
 
+
         custom_paths = {
             'files': ["bin/bamtools", "include/shared/bamtools_global.h", "lib/libbamtools.a",
-                      "lib/libbamtools.%s" % sharedlib_ext, "lib/libbamtools-utils.%s" % sharedlib_ext,
-                      "lib/libjsoncpp.%s" % sharedlib_ext],
+                      "lib/libbamtools.%s" % sharedlib_ext],
             'dirs': ["include/api", "docs"]
         }
+        if LooseVersion(self.version) <= LooseVersion('2.3.0'):
+            custom_paths['files'] += [
+                "lib/libbamtools-utils.%s" % sharedlib_ext,
+                "lib/libjsoncpp.%s" % sharedlib_ext]
 
         super(EB_BamTools, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/b/bamtools.py
+++ b/easybuild/easyblocks/b/bamtools.py
@@ -57,15 +57,23 @@ class EB_BamTools(MakeCp, CMakeMake):
 
         sharedlib_ext = get_shared_lib_ext()
 
-
         custom_paths = {
-            'files': ["bin/bamtools", "include/shared/bamtools_global.h", "lib/libbamtools.a",
-                      "lib/libbamtools.%s" % sharedlib_ext],
-            'dirs': ["include/api", "docs"]
+            'files': [
+                "bin/bamtools",
+                "include/shared/bamtools_global.h",
+                "lib/libbamtools.a",
+                "lib/libbamtools.%s" % sharedlib_ext],
+            'dirs': [
+                "include/api",
+                "docs"]
         }
         if LooseVersion(self.version) < LooseVersion('2.3.0'):
+            #Buid environment changed https://github.com/pezmaster31/bamtools/commit/9cfa70bfe9cdf1b6adc06beb88246b45fdd6250a
             custom_paths['files'] += [
                 "lib/libbamtools-utils.%s" % sharedlib_ext,
                 "lib/libjsoncpp.%s" % sharedlib_ext]
-
+        else:
+            custom_paths['files'] += [
+                "lib/libbamtools-utils.a",
+                "lib/libjsoncpp.a"]
         super(EB_BamTools, self).sanity_check_step(custom_paths=custom_paths)


### PR DESCRIPTION
Newer versions of bamtools no longer include the shared libraries for bamtools-utils and jsoncpp