### PR TITLE
Updated custom_paths for picard-1.124 and above

### DIFF
--- a/easybuild/easyblocks/p/picard.py
+++ b/easybuild/easyblocks/p/picard.py
@@ -72,23 +72,116 @@ class EB_picard(EasyBlock):
 
     def sanity_check_step(self):
         """Custom sanity check for picard"""
-        jar_files = ['picard']
-        if LooseVersion(self.version) < LooseVersion('1.115'):
-            jar_files.append('sam')
+        """All versions prior to 1.124 have these jar files"""
         if LooseVersion(self.version) < LooseVersion('1.124'):
-            custom_paths = {
-                'files': ["%s-%s.jar" % (x, self.version) for x in jar_files],
-                'dirs': [],
-            }
+            jar_files = [
+                'picard-%s' % self.version,
+                
+                'AddOrReplaceReadGroups',
+                'BamIndexStats',
+                'BamToBfq',
+                'BuildBamIndex',
+                'CalculateHsMetrics',
+                'CheckIlluminaDirectory',
+                'CleanSam',
+                'CollectAlignmentSummaryMetrics',
+                'CollectGcBiasMetrics',
+                'CollectInsertSizeMetrics',
+                'CollectMultipleMetrics',
+                'CollectRnaSeqMetrics',
+                'CollectTargetedPcrMetrics',
+                'CompareSAMs',
+                'CreateSequenceDictionary',
+                'DownsampleSam',
+                'EstimateLibraryComplexity',
+                'ExtractIlluminaBarcodes',
+                'ExtractSequences',
+                'FastqToSam',
+                'FilterSamReads',
+                'FixMateInformation',
+                'IlluminaBasecallsToFastq',
+                'IlluminaBasecallsToSam',
+                'IntervalListTools',
+                'MakeSitesOnlyVcf',
+                'MarkDuplicates',
+                'MarkIlluminaAdapters',
+                'MeanQualityByCycle',
+                'MergeBamAlignment',
+                'MergeSamFiles',
+                'MergeVcfs',
+                'NormalizeFasta',
+                'QualityScoreDistribution',
+                'ReorderSam',
+                'ReplaceSamHeader',
+                'RevertSam',
+                'SamFormatConverter',
+                'SamToFastq',
+                'SortSam',
+                'SplitVcfs',
+                'ValidateSamFile',
+                'VcfFormatConverter',
+                'ViewSam',
+            ]
+            
+            """The following jar files were only available in the specified versions of picard"""
+            if LooseVersion(self.version) >= LooseVersion('1.100') and LooseVersion(self.version) < LooseVersion('1.114'):
+                jar_files += [
+                    'sam-%s' % self.version,
+                    'tribble-%s' % self.version,
+                    'variant-%s' % self.version,
+                ]
+            if LooseVersion(self.version) >= LooseVersion('1.109'):
+                jar_files += [
+                    'RevertOriginalBaseQualitiesAndAddMateCigar',
+                ]
+            if LooseVersion(self.version) >= LooseVersion('1.111'):
+                jar_files += [
+                    'GatherBamFiles',
+                ]
+            if LooseVersion(self.version) >= LooseVersion('1.113'):
+                jar_files += [
+                    'AddCommentsToBam',
+                    'CollectWgsMetrics',
+                ]
+            if LooseVersion(self.version) >= LooseVersion('1.114'):
+                jar_files += [
+                    'htsjdk-%s' % self.version,
+                ]
+            if LooseVersion(self.version) >= LooseVersion('1.119'):
+                jar_files += [
+                    'CollectBaseDistributionByCycle',
+                    'FifoBuffer',
+                ]
+            if LooseVersion(self.version) >= LooseVersion('1.120'):
+                jar_files += [
+                    'BedToIntervalList',
+                ]
+            if LooseVersion(self.version) >= LooseVersion('1.121'):
+                jar_files += [
+                    'SortVcf',
+                ]
+            if LooseVersion(self.version) >= LooseVersion('1.122'):
+                jar_files += [
+                    'CollectHiSeqXPfFailMetrics',
+                    'GenotypeConcordance',
+                    'MarkDuplicatesWithMateCigar',
+                    'UpdateVcfSequenceDictionary',
+                    'VcfToIntervalList',
+                ]
         else:
-            custom_paths = {
-                'files': [
-                    'picard.jar',
-                    'picard-lib.jar',
-                    'htsjdk-%s.jar' % self.version,
-                ],
-                'dirs': [],
-            }
+            """Starting with v1.124 a major structural change was made to picard"""
+            """All versions >= 1.124 now only have these jar files"""
+            jar_files = [
+                'htsjdk-%s' % self.version,
+                'picard',
+                'picard-lib'
+            ]
+        
+        custom_paths = {
+            'files': ["%s.jar" % (x) for x in jar_files],
+            'dirs': [],
+        }
+
         super(EB_picard, self).sanity_check_step(custom_paths=custom_paths)
 
     def make_module_extra(self):

--- a/easybuild/easyblocks/p/picard.py
+++ b/easybuild/easyblocks/p/picard.py
@@ -125,49 +125,39 @@ class EB_picard(EasyBlock):
             
             """The following jar files were only available in the specified versions of picard"""
             if LooseVersion(self.version) >= LooseVersion('1.100') and LooseVersion(self.version) < LooseVersion('1.114'):
-                jar_files += [
+                jar_files.extend([
                     'sam-%s' % self.version,
                     'tribble-%s' % self.version,
                     'variant-%s' % self.version,
-                ]
+                ])
             if LooseVersion(self.version) >= LooseVersion('1.109'):
-                jar_files += [
-                    'RevertOriginalBaseQualitiesAndAddMateCigar',
-                ]
+                jar_files.append('RevertOriginalBaseQualitiesAndAddMateCigar')
             if LooseVersion(self.version) >= LooseVersion('1.111'):
-                jar_files += [
-                    'GatherBamFiles',
-                ]
+                jar_files.append('GatherBamFiles')
             if LooseVersion(self.version) >= LooseVersion('1.113'):
-                jar_files += [
+                jar_files.extend([
                     'AddCommentsToBam',
                     'CollectWgsMetrics',
-                ]
+                ])
             if LooseVersion(self.version) >= LooseVersion('1.114'):
-                jar_files += [
-                    'htsjdk-%s' % self.version,
-                ]
+                jar_files.append('htsjdk-%s' % self.version)
             if LooseVersion(self.version) >= LooseVersion('1.119'):
-                jar_files += [
+                jar_files.extend([
                     'CollectBaseDistributionByCycle',
                     'FifoBuffer',
-                ]
+                ])
             if LooseVersion(self.version) >= LooseVersion('1.120'):
-                jar_files += [
-                    'BedToIntervalList',
-                ]
+                jar_files.append('BedToIntervalList')
             if LooseVersion(self.version) >= LooseVersion('1.121'):
-                jar_files += [
-                    'SortVcf',
-                ]
+                jar_files.append('SortVcf')
             if LooseVersion(self.version) >= LooseVersion('1.122'):
-                jar_files += [
+                jar_files.extend([
                     'CollectHiSeqXPfFailMetrics',
                     'GenotypeConcordance',
                     'MarkDuplicatesWithMateCigar',
                     'UpdateVcfSequenceDictionary',
                     'VcfToIntervalList',
-                ]
+                ])
         else:
             """Starting with v1.124 a major structural change was made to picard"""
             """All versions >= 1.124 now only have these jar files"""

--- a/easybuild/easyblocks/p/picard.py
+++ b/easybuild/easyblocks/p/picard.py
@@ -76,18 +76,15 @@ class EB_picard(EasyBlock):
         if LooseVersion(self.version) < LooseVersion('1.124'):
             jar_files = [
                 'picard-%s' % self.version,
-                'AddOrReplaceReadGroups',
                 'BamIndexStats',
                 'BamToBfq',
                 'BuildBamIndex',
                 'CalculateHsMetrics',
-                'CheckIlluminaDirectory',
                 'CleanSam',
                 'CollectAlignmentSummaryMetrics',
                 'CollectGcBiasMetrics',
                 'CollectInsertSizeMetrics',
                 'CollectMultipleMetrics',
-                'CollectRnaSeqMetrics',
                 'CollectTargetedPcrMetrics',
                 'CompareSAMs',
                 'CreateSequenceDictionary',
@@ -129,6 +126,12 @@ class EB_picard(EasyBlock):
                     'tribble-%s' % self.version,
                     'variant-%s' % self.version,
                 ])
+            if LooseVersion(self.version) >= LooseVersion('1.41'):
+                jar_files.append('AddOrReplaceReadGroups')
+            if LooseVersion(self.version) >= LooseVersion('1.46'):
+                jar_files.append('CollectRnaSeqMetrics')
+            if LooseVersion(self.version) >= LooseVersion('1.66'):
+                jar_files.append('CheckIlluminaDirectory')
             if LooseVersion(self.version) >= LooseVersion('1.109'):
                 jar_files.append('RevertOriginalBaseQualitiesAndAddMateCigar')
             if LooseVersion(self.version) >= LooseVersion('1.111'):

--- a/easybuild/easyblocks/p/picard.py
+++ b/easybuild/easyblocks/p/picard.py
@@ -75,10 +75,20 @@ class EB_picard(EasyBlock):
         jar_files = ['picard']
         if LooseVersion(self.version) < LooseVersion('1.115'):
             jar_files.append('sam')
-        custom_paths = {
-            'files': ["%s-%s.jar" % (x, self.version) for x in jar_files],
-            'dirs': [],
-        }
+        if LooseVersion(self.version) < LooseVersion('1.124'):
+            custom_paths = {
+                'files': ["%s-%s.jar" % (x, self.version) for x in jar_files],
+                'dirs': [],
+            }
+        else:
+            custom_paths = {
+                'files': [
+                    'picard.jar',
+                    'picard-lib.jar',
+                    'htsjdk-%s.jar' % self.version,
+                ],
+                'dirs': [],
+            }
         super(EB_picard, self).sanity_check_step(custom_paths=custom_paths)
 
     def make_module_extra(self):

--- a/easybuild/easyblocks/p/picard.py
+++ b/easybuild/easyblocks/p/picard.py
@@ -72,94 +72,9 @@ class EB_picard(EasyBlock):
 
     def sanity_check_step(self):
         """Custom sanity check for picard"""
-        # All versions prior to 1.124 have these jar files
+        # All versions prior to 1.124 have this jar file
         if LooseVersion(self.version) < LooseVersion('1.124'):
-            jar_files = [
-                'picard-%s' % self.version,
-                'BamIndexStats',
-                'BamToBfq',
-                'BuildBamIndex',
-                'CalculateHsMetrics',
-                'CleanSam',
-                'CollectAlignmentSummaryMetrics',
-                'CollectGcBiasMetrics',
-                'CollectInsertSizeMetrics',
-                'CollectMultipleMetrics',
-                'CollectTargetedPcrMetrics',
-                'CompareSAMs',
-                'CreateSequenceDictionary',
-                'DownsampleSam',
-                'EstimateLibraryComplexity',
-                'ExtractIlluminaBarcodes',
-                'ExtractSequences',
-                'FastqToSam',
-                'FilterSamReads',
-                'FixMateInformation',
-                'IlluminaBasecallsToFastq',
-                'IlluminaBasecallsToSam',
-                'IntervalListTools',
-                'MakeSitesOnlyVcf',
-                'MarkDuplicates',
-                'MarkIlluminaAdapters',
-                'MeanQualityByCycle',
-                'MergeBamAlignment',
-                'MergeSamFiles',
-                'MergeVcfs',
-                'NormalizeFasta',
-                'QualityScoreDistribution',
-                'ReorderSam',
-                'ReplaceSamHeader',
-                'RevertSam',
-                'SamFormatConverter',
-                'SamToFastq',
-                'SortSam',
-                'SplitVcfs',
-                'ValidateSamFile',
-                'VcfFormatConverter',
-                'ViewSam',
-            ]
-            
-            # The following jar files were only available in the specified versions of picard
-            if LooseVersion(self.version) >= LooseVersion('1.100') and LooseVersion(self.version) < LooseVersion('1.114'):
-                jar_files.extend([
-                    'sam-%s' % self.version,
-                    'tribble-%s' % self.version,
-                    'variant-%s' % self.version,
-                ])
-            if LooseVersion(self.version) >= LooseVersion('1.41'):
-                jar_files.append('AddOrReplaceReadGroups')
-            if LooseVersion(self.version) >= LooseVersion('1.46'):
-                jar_files.append('CollectRnaSeqMetrics')
-            if LooseVersion(self.version) >= LooseVersion('1.66'):
-                jar_files.append('CheckIlluminaDirectory')
-            if LooseVersion(self.version) >= LooseVersion('1.109'):
-                jar_files.append('RevertOriginalBaseQualitiesAndAddMateCigar')
-            if LooseVersion(self.version) >= LooseVersion('1.111'):
-                jar_files.append('GatherBamFiles')
-            if LooseVersion(self.version) >= LooseVersion('1.113'):
-                jar_files.extend([
-                    'AddCommentsToBam',
-                    'CollectWgsMetrics',
-                ])
-            if LooseVersion(self.version) >= LooseVersion('1.114'):
-                jar_files.append('htsjdk-%s' % self.version)
-            if LooseVersion(self.version) >= LooseVersion('1.119'):
-                jar_files.extend([
-                    'CollectBaseDistributionByCycle',
-                    'FifoBuffer',
-                ])
-            if LooseVersion(self.version) >= LooseVersion('1.120'):
-                jar_files.append('BedToIntervalList')
-            if LooseVersion(self.version) >= LooseVersion('1.121'):
-                jar_files.append('SortVcf')
-            if LooseVersion(self.version) >= LooseVersion('1.122'):
-                jar_files.extend([
-                    'CollectHiSeqXPfFailMetrics',
-                    'GenotypeConcordance',
-                    'MarkDuplicatesWithMateCigar',
-                    'UpdateVcfSequenceDictionary',
-                    'VcfToIntervalList',
-                ])
+            jar_files = ['picard-%s' % self.version]
         else:
             # Starting with v1.124 a major structural change was made to picard
             # All versions >= 1.124 now only have these jar files

--- a/easybuild/easyblocks/p/picard.py
+++ b/easybuild/easyblocks/p/picard.py
@@ -168,7 +168,7 @@ class EB_picard(EasyBlock):
             ]
         
         custom_paths = {
-            'files': ["%s.jar" % (x) for x in jar_files],
+            'files': ["%s.jar" % x for x in jar_files],
             'dirs': [],
         }
 

--- a/easybuild/easyblocks/p/picard.py
+++ b/easybuild/easyblocks/p/picard.py
@@ -72,11 +72,10 @@ class EB_picard(EasyBlock):
 
     def sanity_check_step(self):
         """Custom sanity check for picard"""
-        """All versions prior to 1.124 have these jar files"""
+        # All versions prior to 1.124 have these jar files
         if LooseVersion(self.version) < LooseVersion('1.124'):
             jar_files = [
                 'picard-%s' % self.version,
-                
                 'AddOrReplaceReadGroups',
                 'BamIndexStats',
                 'BamToBfq',
@@ -123,7 +122,7 @@ class EB_picard(EasyBlock):
                 'ViewSam',
             ]
             
-            """The following jar files were only available in the specified versions of picard"""
+            # The following jar files were only available in the specified versions of picard
             if LooseVersion(self.version) >= LooseVersion('1.100') and LooseVersion(self.version) < LooseVersion('1.114'):
                 jar_files.extend([
                     'sam-%s' % self.version,
@@ -159,8 +158,8 @@ class EB_picard(EasyBlock):
                     'VcfToIntervalList',
                 ])
         else:
-            """Starting with v1.124 a major structural change was made to picard"""
-            """All versions >= 1.124 now only have these jar files"""
+            # Starting with v1.124 a major structural change was made to picard
+            # All versions >= 1.124 now only have these jar files
             jar_files = [
                 'htsjdk-%s' % self.version,
                 'picard',


### PR DESCRIPTION
A restructure of picard at v1.124 means only a single `picard.jar` file is created