### PR TITLE
update sanity check in PETSc/SLEPc easyblocks for v3.6.x

### DIFF
--- a/easybuild/easyblocks/p/petsc.py
+++ b/easybuild/easyblocks/p/petsc.py
@@ -270,18 +270,17 @@ class EB_PETSc(ConfigureMake):
 
         guesses = super(EB_PETSc, self).make_module_req_guess()
 
-        prefix1 = ""
-        prefix2 = ""
+        prefix1 = ''
+        prefix2 = ''
         if self.cfg['sourceinstall']:
             prefix1 = self.petsc_subdir
             prefix2 = os.path.join(self.petsc_subdir, self.petsc_arch)
 
         guesses.update({
-                        'PATH': [os.path.join(prefix1, "bin")],
-                        'CPATH': [os.path.join(prefix2, "include"),
-                                  os.path.join(prefix1, "include")],
-                        'LD_LIBRARY_PATH': [os.path.join(prefix2, "lib")]
-                        })
+            'CPATH': [os.path.join(prefix2, 'include'), os.path.join(prefix1, 'include')],
+            'LD_LIBRARY_PATH': [os.path.join(prefix2, 'lib')],
+            'PATH': [os.path.join(prefix1, 'bin')],
+        })
 
         return guesses
 
@@ -292,7 +291,6 @@ class EB_PETSc(ConfigureMake):
         if self.cfg['sourceinstall']:
             txt += self.module_generator.set_environment('PETSC_DIR', os.path.join(self.installdir, self.petsc_subdir))
             txt += self.module_generator.set_environment('PETSC_ARCH', self.petsc_arch)
-
         else:
             txt += self.module_generator.set_environment('PETSC_DIR', self.installdir)
 
@@ -301,8 +299,8 @@ class EB_PETSc(ConfigureMake):
     def sanity_check_step(self):
         """Custom sanity check for PETSc"""
 
-        prefix1 = ""
-        prefix2 = ""
+        prefix1 = ''
+        prefix2 = ''
         if self.cfg['sourceinstall']:
             prefix1 = self.petsc_subdir
             prefix2 = os.path.join(self.petsc_subdir, self.petsc_arch)
@@ -310,12 +308,16 @@ class EB_PETSc(ConfigureMake):
         if self.cfg['shared_libs']:
             libext = get_shared_lib_ext()
         else:
-            libext = "a"
+            libext = 'a'
 
-        custom_paths = {
-                        'files': [os.path.join(prefix2, "lib", "libpetsc.%s" % libext)],
-                        'dirs': [os.path.join(prefix1, "bin"), os.path.join(prefix2, "conf"),
-                                 os.path.join(prefix1, "include"), os.path.join(prefix2, "include")]
-                       }
+            custom_paths = {
+                'files': [os.path.join(prefix2, 'lib', 'libpetsc.%s' % libext)],
+                'dirs': [os.path.join(prefix1, 'bin'), os.path.join(prefix2, 'conf'),
+                         os.path.join(prefix1, 'include'), os.path.join(prefix2, 'include')]
+            }
+            if LooseVersion(self.version) < LooseVersion('3.6'):
+                custom_paths['dirs'].append(os.path.join(prefix2, 'conf'))
+            else:
+                custom_paths['dirs'].append(os.path.join(prefix2, 'lib', 'petsc', 'conf'))
 
         super(EB_PETSc, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/p/petsc.py
+++ b/easybuild/easyblocks/p/petsc.py
@@ -312,8 +312,8 @@ class EB_PETSc(ConfigureMake):
 
             custom_paths = {
                 'files': [os.path.join(prefix2, 'lib', 'libpetsc.%s' % libext)],
-                'dirs': [os.path.join(prefix1, 'bin'), os.path.join(prefix2, 'conf'),
-                         os.path.join(prefix1, 'include'), os.path.join(prefix2, 'include')]
+                'dirs': [os.path.join(prefix1, 'bin'), os.path.join(prefix1, 'include'),
+                         os.path.join(prefix2, 'include')]
             }
             if LooseVersion(self.version) < LooseVersion('3.6'):
                 custom_paths['dirs'].append(os.path.join(prefix2, 'conf'))

--- a/easybuild/easyblocks/s/slepc.py
+++ b/easybuild/easyblocks/s/slepc.py
@@ -145,6 +145,10 @@ class EB_SLEPc(ConfigureMake):
         """Custom sanity check for SLEPc"""
         custom_paths = {
             'files': [],
-            'dirs': [os.path.join(self.slepc_subdir, x) for x in ["conf", "include", "lib"]],
+            'dirs': [os.path.join(self.slepc_subdir, x) for x in ['include', 'lib']],
         }
+        if LooseVersion(self.version) < LooseVersion('3.6'):
+            custom_paths['dirs'].append('conf')
+        else:
+            custom_paths['dirs'].append(os.path.join('lib', 'slepc', 'conf'))
         super(EB_SLEPc, self).sanity_check_step(custom_paths=custom_paths)


### PR DESCRIPTION
`conf` directory is moved in PETSc/SLEPc 3.6, cfr. http://www.mcs.anl.gov/petsc/documentation/changes/36.html and http://slepc.upv.es/download/changes.htm