### PR TITLE
Add an option to skip the sanitizer tests of Clang

### DIFF
--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -187,10 +187,7 @@ class EB_Clang(CMakeMake):
                 self.log.warn("The stacksize limit is set to unlimited. This causes the ThreadSanitizer "
                               "to fail. The sanitizers tests will be disabled unless --strict=error is used.")
 
-            if self.cfg['skip_sanitizer_tests']:
-                disable_san_tests = True
-
-            if disable_san_tests and build_option('strict') != run.ERROR:
+            if (disable_san_tests or self.cfg['skip_sanitizer_tests']) and build_option('strict') != run.ERROR:
                 self.log.debug("Disabling the sanitizer tests")
                 self.disable_sanitizer_tests()
 

--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -67,6 +67,8 @@ class EB_Clang(CMakeMake):
             'bootstrap': [True, "Bootstrap Clang using GCC", CUSTOM],
             'usepolly': [False, "Build Clang with polly", CUSTOM],
             'static_analyzer': [True, "Install the static analyser of Clang", CUSTOM],
+            # The sanitizer tests often fail on HPC systems due to the 'weird' environment.
+            'skip_sanitizer_tests': [False, "Do not run the sanitizer tests", CUSTOM],
         }
 
         return CMakeMake.extra_options(extra_vars)
@@ -184,6 +186,9 @@ class EB_Clang(CMakeMake):
                 disable_san_tests = True
                 self.log.warn("The stacksize limit is set to unlimited. This causes the ThreadSanitizer "
                               "to fail. The sanitizers tests will be disabled unless --strict=error is used.")
+
+            if self.cfg['skip_sanitizer_tests']:
+                disable_san_tests = True
 
             if disable_san_tests and build_option('strict') != run.ERROR:
                 self.disable_sanitizer_tests()

--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -191,6 +191,7 @@ class EB_Clang(CMakeMake):
                 disable_san_tests = True
 
             if disable_san_tests and build_option('strict') != run.ERROR:
+                self.log.debug("Disabling the sanitizer tests")
                 self.disable_sanitizer_tests()
 
         # Create and enter build directory.


### PR DESCRIPTION
These sanitizer tests often fail on HPC systems due to the 'weird'
evironment. It doesn't neccessarily mean that they don't work (they
usually do).


@boegel please review