### PR TITLE
update Molpro easyblock to support binary installs and 2015 version

### DIFF
--- a/easybuild/easyblocks/m/molpro.py
+++ b/easybuild/easyblocks/m/molpro.py
@@ -70,7 +70,7 @@ class EB_Molpro(ConfigureMake, Binary):
         if self.cfg['precompiled_binaries']:
             Binary.extract_step(self)
         else:
-            super(EB_Molpro, self).extract_step()
+            ConfigureMake.extract_step(self)
 
     def configure_step(self):
         """Custom configuration procedure for Molpro: use 'configure -batch'."""

--- a/easybuild/easyblocks/m/molpro.py
+++ b/easybuild/easyblocks/m/molpro.py
@@ -50,7 +50,7 @@ class EB_Molpro(ConfigureMake, Binary):
         # Combine extra variables from Binary and ConfigureMake easyblocks as
         # well as those needed for Molpro specifically
         extra_vars = Binary.extra_options()
-        extra_vars = super.extra_options(extra_vars)
+        extra_vars = ConfigureMake.extra_options(extra_vars)
         extra_vars.update({
             'precompiled_binaries': [False, "Are we installing precompiled binaries?", CUSTOM],
         })
@@ -70,7 +70,7 @@ class EB_Molpro(ConfigureMake, Binary):
         if self.cfg['precompiled_binaries']:
             Binary.extract_step(self)
         else:
-            super.extract_step(self)
+            super(EB_Molpro, self).extract_step()
 
     def configure_step(self):
         """Custom configuration procedure for Molpro: use 'configure -batch'."""
@@ -164,7 +164,7 @@ class EB_Molpro(ConfigureMake, Binary):
 
     def build_step(self):
         if not self.cfg['precompiled_binaries']:
-            super.build_step(self)
+            super(EB_Molpro, self).build_step()
 
     def test_step(self):
         
@@ -217,7 +217,7 @@ class EB_Molpro(ConfigureMake, Binary):
             if os.path.isfile(self.license_token):
                 run_cmd("make tuning")
 
-            super.install_step(self)
+            super(EB_Molpro, self).install_step()
 
             # put original LAUNCHER definition back in place in bin/molpro that got installed,
             # since the value used during installation point to temporary files

--- a/easybuild/easyblocks/m/molpro.py
+++ b/easybuild/easyblocks/m/molpro.py
@@ -92,7 +92,6 @@ class EB_Molpro(ConfigureMake, Binary):
         
         # Only do the rest of the configuration if we're building from source 
         if not self.cfg['precompiled_binaries']:
-
             # installation prefix
             self.cfg.update('configopts', "-prefix %s" % self.installdir)
 
@@ -211,9 +210,7 @@ class EB_Molpro(ConfigureMake, Binary):
                         r"directory .* does not exist, try to create [Y]/n\n": '',
                 }
                 run_cmd_qa(cmd, qa=qa, std_qa=stdqa, log_all=True, simple=True)
-
         else:
-
             if os.path.isfile(self.license_token):
                 run_cmd("make tuning")
 

--- a/easybuild/easyblocks/m/molpro.py
+++ b/easybuild/easyblocks/m/molpro.py
@@ -249,7 +249,7 @@ class EB_Molpro(ConfigureMake, Binary):
         prefix_subdir = os.path.basename(self.full_prefix)
         files_to_check = ['bin/molpro']
         dirs_to_check = []
-        if not self.cfg['precompiled_binaries']:
+        if LooseVersion(self.version) >= LooseVersion('2015') or not self.cfg['precompiled_binaries']:
             files_to_check.extend(['bin/molpro.exe'])
             dirs_to_check.extend(['doc', 'examples', 'utilities'])
 


### PR DESCRIPTION
builds on top of #684 by by @valtandor, fixes some style issues, adds support for installing the 2015 version of Molpro and replaces use of `fileinput` with `apply_regex_substitutions`