### PR TITLE
Fixed license checking and CPATH definition

### DIFF
--- a/easybuild/easyblocks/p/pgi.py
+++ b/easybuild/easyblocks/p/pgi.py
@@ -41,6 +41,7 @@ import easybuild.tools.environment as env
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.filetools import find_flexlm_license
 from easybuild.tools.run import run_cmd
 
 class EB_PGI(EasyBlock):

--- a/easybuild/easyblocks/p/pgi.py
+++ b/easybuild/easyblocks/p/pgi.py
@@ -84,7 +84,6 @@ class EB_PGI(EasyBlock):
                 self.log.info("Using PGI license specifications from %s: %s", self.license_env_var, lic_specs)
 
             self.license_file = os.pathsep.join(lic_specs)
-            self.cfg['license_file'] = self.license_file
             env.setvar(self.license_env_var, self.license_file)
 
         else:

--- a/easybuild/easyblocks/p/pgi.py
+++ b/easybuild/easyblocks/p/pgi.py
@@ -1,5 +1,6 @@
 ##
-# Copyright 2015-2015 Bart Oldeman
+# Copyright 2015-2016 Bart Oldeman
+# Copyright 2016-2016 Forschungszentrum Juelich
 #
 # This file is triple-licensed under GPLv2 (see below), MIT, and
 # BSD three-clause licenses.
@@ -29,12 +30,14 @@
 EasyBuild support for installing PGI compilers, implemented as an easyblock
 
 @author: Bart Oldeman (McGill University, Calcul Quebec, Compute Canada)
+@author: Damian Alvarez (Forschungszentrum Juelich)
 """
 import os
 import fileinput
 import re
 import sys
 
+import easybuild.tools.environment as env
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
@@ -58,16 +61,88 @@ class EB_PGI(EasyBlock):
     def __init__(self, *args, **kwargs):
         """Easyblock constructor, define custom class variables specific to PGI."""
         super(EB_PGI, self).__init__(*args, **kwargs)
-        if not self.cfg['license_file']:
-            self.cfg['license_file'] = 'UNKNOWN'
+
+        self.license_file = 'UNKNOWN'
+        self.license_env_var = 'UNKNOWN' # Probably not really necessary for PGI
+
         self.install_subdir = os.path.join('linux86-64', self.version)
 
     def configure_step(self):
         """
-        Dummy configure method, just a license check
+        Handle license file. It mimics intelbase.py behaviour. It should be merged into the framekwork
+        at some point
         """
-        if not os.path.exists(self.cfg['license_file']):
-            raise EasyBuildError("Non-existing license file specified: %s", self.cfg['license_file'])
+        lic_env_var = None  # environment variable that will be used
+        default_lic_env_var = 'LM_LICENSE_FILE'
+        lic_env_vars = [default_lic_env_var]
+        env_var_names = ', '.join(['$%s' % x for x in lic_env_vars])
+        lic_env_var_vals = [(var, os.getenv(var)) for var in lic_env_vars]
+        license_specs = [(var, e) for (var, val) in lic_env_var_vals if val is not None for e in val.split(os.pathsep)]
+
+        if not license_specs:
+            self.log.debug("No env var from %s set, trying 'license_file' easyconfig parameter..." % lic_env_vars)
+            # obtain license path
+            self.license_file = self.cfg['license_file']
+
+            if self.license_file:
+                self.log.info("Using license file %s" % self.license_file)
+            else:
+                raise EasyBuildError("No license file defined, maybe set one these env vars: %s", env_var_names)
+
+            # verify license path
+            if not os.path.exists(self.license_file):
+                raise EasyBuildError("%s not found; correct 'license_file', or define one of the these env vars: %s",
+                                     self.license_file, env_var_names)
+
+            # set default environment variable for license specification
+            env.setvar(default_lic_env_var, self.license_file)
+            self.license_env_var = default_lic_env_var
+        else:
+            valid_license_specs = {}
+            # iterate through entries in environment variables until a valid license specification is found
+            # valid options are:
+            # * an (existing) license file
+            # * a directory containing atleast one file named *.dat (only one is used, first listed alphabetically)
+            # * a license server, format: <port>@<server>
+            server_port_regex = re.compile('^[0-9]+@\S+$')
+            for (lic_env_var, license_spec) in license_specs:
+                # a value that seems to match a license server specification
+                if server_port_regex.match(license_spec):
+                    self.log.info("Found license server spec %s in $%s, retaining it" % (license_spec, lic_env_var))
+                    valid_license_specs.setdefault(lic_env_var, set()).add(license_spec)
+
+                # an (existing) license file
+                elif os.path.isfile(license_spec):
+                    self.log.info("Found existing license file %s via $%s, retaining it" % (license_spec, lic_env_var))
+                    valid_license_specs.setdefault(lic_env_var, set()).add(license_spec)
+
+                # a directory, should contain at least one *.dat file (use only the first one)
+                elif os.path.isdir(license_spec):
+                    lic_files = glob.glob("%s/*.dat" % license_spec)
+                    if not lic_files:
+                        self.log.debug("Found no license files (*.dat) in %s" % license_spec)
+                        continue
+                    # just pick the first .dat, if it's not correct, $LM_LICENSE_FILE should be adjusted instead
+                    valid_license_specs.setdefault(lic_env_var, set()).add(lic_files[0])
+                    self.log.info('Picked the first *.lic file from $%s: %s' % (lic_env_var, lic_files[0]))
+
+            if not valid_license_specs:
+                raise EasyBuildError("Cannot find a valid license specification in %s", license_specs)
+
+            # only retain one environment variable (by order of preference), retain all valid matches for that env var
+            for lic_env_var in lic_env_vars:
+                if lic_env_var in valid_license_specs:
+                    self.license_env_var = lic_env_var
+                    retained = valid_license_specs[self.license_env_var]
+                    self.license_file = os.pathsep.join(retained)
+                    break
+            if self.license_file is None or self.license_env_var is None:
+                raise EasyBuildError("self.license_file or self.license_env_var still None, "
+                                     "something went horribly wrong...")
+
+            self.cfg['license_file'] = self.license_file
+            env.setvar(self.license_env_var, self.license_file)
+            self.log.info("Using PGI license specifications from $%s: %s", self.license_env_var, self.license_file)
 
     def build_step(self):
         """
@@ -115,11 +190,12 @@ class EB_PGI(EasyBlock):
         dirs = super(EB_PGI, self).make_module_req_guess()
         for key in dirs:
             dirs[key] = [os.path.join(self.install_subdir, d) for d in dirs[key]]
+        dirs.update({'CPATH': ''})
         return dirs
 
     def make_module_extra(self):
         """Add environment variables LM_LICENSE_FILE and PGI for license file and PGI location"""
         txt = super(EB_PGI, self).make_module_extra()
-        txt += self.module_generator.prepend_paths('LM_LICENSE_FILE', [self.cfg['license_file']], allow_abs=True)
+        txt += self.module_generator.prepend_paths(self.license_env_var, [self.license_file], allow_abs=True, expand_relpaths=False)
         txt += self.module_generator.set_environment('PGI', self.installdir)
         return txt

--- a/easybuild/easyblocks/p/pgi.py
+++ b/easybuild/easyblocks/p/pgi.py
@@ -194,7 +194,7 @@ class EB_PGI(EasyBlock):
         # $CPATH should not be defined in module for PGI, it causes problems
         # cfr. https://github.com/hpcugent/easybuild-easyblocks/issues/830
         if 'CPATH' in dirs:
-            self.log.info("Removing $CPATH entry: %s", dirs['CPATH']
+            self.log.info("Removing $CPATH entry: %s", dirs['CPATH'])
             del dirs['CPATH']
 
         return dirs

--- a/easybuild/easyblocks/p/pgi.py
+++ b/easybuild/easyblocks/p/pgi.py
@@ -69,80 +69,27 @@ class EB_PGI(EasyBlock):
 
     def configure_step(self):
         """
-        Handle license file. It mimics intelbase.py behaviour. It should be merged into the framekwork
-        at some point
+        Handle license file. 
         """
-        lic_env_var = None  # environment variable that will be used
-        default_lic_env_var = 'LM_LICENSE_FILE'
-        lic_env_vars = [default_lic_env_var]
-        env_var_names = ', '.join(['$%s' % x for x in lic_env_vars])
-        lic_env_var_vals = [(var, os.getenv(var)) for var in lic_env_vars]
-        license_specs = [(var, e) for (var, val) in lic_env_var_vals if val is not None for e in val.split(os.pathsep)]
+        default_lic_env_var = 'PGROUPD_LICENSE_FILE'
+        lic_specs, self.license_env_var = find_flexlm_license(custom_env_vars=[default_lic_env_var],
+                                                              lic_specs=[self.cfg['license_file']])
 
-        if not license_specs:
-            self.log.debug("No env var from %s set, trying 'license_file' easyconfig parameter..." % lic_env_vars)
-            # obtain license path
-            self.license_file = self.cfg['license_file']
-
-            if self.license_file:
-                self.log.info("Using license file %s" % self.license_file)
+        if lic_specs:
+            if self.license_env_var is None:
+                self.log.info("Using PGI license specifications from 'license_file': %s", lic_specs)
+                self.license_env_var = default_lic_env_var
             else:
-                raise EasyBuildError("No license file defined, maybe set one these env vars: %s", env_var_names)
+                self.log.info("Using PGI license specifications from %s: %s", self.license_env_var, lic_specs)
 
-            # verify license path
-            if not os.path.exists(self.license_file):
-                raise EasyBuildError("%s not found; correct 'license_file', or define one of the these env vars: %s",
-                                     self.license_file, env_var_names)
-
-            # set default environment variable for license specification
-            env.setvar(default_lic_env_var, self.license_file)
-            self.license_env_var = default_lic_env_var
-        else:
-            valid_license_specs = {}
-            # iterate through entries in environment variables until a valid license specification is found
-            # valid options are:
-            # * an (existing) license file
-            # * a directory containing atleast one file named *.dat (only one is used, first listed alphabetically)
-            # * a license server, format: <port>@<server>
-            server_port_regex = re.compile('^[0-9]+@\S+$')
-            for (lic_env_var, license_spec) in license_specs:
-                # a value that seems to match a license server specification
-                if server_port_regex.match(license_spec):
-                    self.log.info("Found license server spec %s in $%s, retaining it" % (license_spec, lic_env_var))
-                    valid_license_specs.setdefault(lic_env_var, set()).add(license_spec)
-
-                # an (existing) license file
-                elif os.path.isfile(license_spec):
-                    self.log.info("Found existing license file %s via $%s, retaining it" % (license_spec, lic_env_var))
-                    valid_license_specs.setdefault(lic_env_var, set()).add(license_spec)
-
-                # a directory, should contain at least one *.dat file (use only the first one)
-                elif os.path.isdir(license_spec):
-                    lic_files = glob.glob("%s/*.dat" % license_spec)
-                    if not lic_files:
-                        self.log.debug("Found no license files (*.dat) in %s" % license_spec)
-                        continue
-                    # just pick the first .dat, if it's not correct, $LM_LICENSE_FILE should be adjusted instead
-                    valid_license_specs.setdefault(lic_env_var, set()).add(lic_files[0])
-                    self.log.info('Picked the first *.lic file from $%s: %s' % (lic_env_var, lic_files[0]))
-
-            if not valid_license_specs:
-                raise EasyBuildError("Cannot find a valid license specification in %s", license_specs)
-
-            # only retain one environment variable (by order of preference), retain all valid matches for that env var
-            for lic_env_var in lic_env_vars:
-                if lic_env_var in valid_license_specs:
-                    self.license_env_var = lic_env_var
-                    retained = valid_license_specs[self.license_env_var]
-                    self.license_file = os.pathsep.join(retained)
-                    break
-            if self.license_file is None or self.license_env_var is None:
-                raise EasyBuildError("self.license_file or self.license_env_var still None, "
-                                     "something went horribly wrong...")
-
+            self.license_file = os.pathsep.join(lic_specs)
             self.cfg['license_file'] = self.license_file
             env.setvar(self.license_env_var, self.license_file)
-            self.log.info("Using PGI license specifications from $%s: %s", self.license_env_var, self.license_file)
+
+        else:
+            raise EasyBuildError("No viable license specifications found; specify 'license_file' or " +
+                                 "define $PGROUPD_LICENSE_FILE or $LM_LICENSE_FILE")
+
 
     def build_step(self):
         """

--- a/easybuild/easyblocks/p/pgi.py
+++ b/easybuild/easyblocks/p/pgi.py
@@ -190,7 +190,13 @@ class EB_PGI(EasyBlock):
         dirs = super(EB_PGI, self).make_module_req_guess()
         for key in dirs:
             dirs[key] = [os.path.join(self.install_subdir, d) for d in dirs[key]]
-        dirs.update({'CPATH': ''})
+
+        # $CPATH should not be defined in module for PGI, it causes problems
+        # cfr. https://github.com/hpcugent/easybuild-easyblocks/issues/830
+        if 'CPATH' in dirs:
+            self.log.info("Removing $CPATH entry: %s", dirs['CPATH']
+            del dirs['CPATH']
+
         return dirs
 
     def make_module_extra(self):


### PR DESCRIPTION
This PR does 2 things:

-Eliminates the `CPATH` definition (see https://github.com/hpcugent/easybuild-easyblocks/issues/830)
-Improves the license checking to be compatible with license servers. It does it in the same was as `IntelBase.py`. In the future, some of the functionality in these 2 places should be moved to the framework (see https://lists.ugent.be/wws/arc/easybuild/2016-02/msg00028.html)