### PR TITLE
Update easyblocks for MPICH and MVAPICH2

### DIFF
--- a/easybuild/easyblocks/m/mpich.py
+++ b/easybuild/easyblocks/m/mpich.py
@@ -90,6 +90,8 @@ class EB_MPICH(ConfigureMake):
             add_configopts.append('--enable-fast')
         # enable shared libraries, using GCC and GNU ld options
         add_configopts.extend(['--enable-shared', '--enable-sharedlibs=gcc'])
+        # enable static libraries
+        add_configopts.extend(['--enable-static'])
         # enable Fortran 77/90 and C++ bindings
         add_configopts.extend(['--enable-f77', '--enable-fc', '--enable-cxx'])
         self.cfg.update('configopts', ' '.join(add_configopts))

--- a/easybuild/easyblocks/m/mpich.py
+++ b/easybuild/easyblocks/m/mpich.py
@@ -31,6 +31,7 @@ EasyBuild support for building and installing the MPICH MPI library and derivati
 @author: Pieter De Baets (Ghent University)
 @author: Jens Timmerman (Ghent University)
 @author: Damian Alvarez (Forschungszentrum Juelich)
+@author: Xavier Besseron (University of Luxembourg)
 """
 
 import os

--- a/easybuild/easyblocks/m/mpich.py
+++ b/easybuild/easyblocks/m/mpich.py
@@ -49,12 +49,11 @@ class EB_MPICH(ConfigureMake):
     - basically redefinition of environment variables
     """
 
-    def __init__(self, *args, **kwargs):
-        """Custom constructor for EB_MPICH easyblock, initialize custom class parameters."""
-        super(EB_MPICH, self).__init__(*args, **kwargs)        
-        # Starting MPICH 3.1.1, libraries have been renamed
+    def use_new_libnames(self):
+        """Tell if the underlying MPICH use the new names for its libraries"""
         # cf http://git.mpich.org/mpich.git/blob_plain/v3.1.1:/CHANGES
-        self.use_new_libnames = LooseVersion(self.version) >= LooseVersion('3.1.1')
+        # MPICH changed its library names sinceversion 3.1.1
+        return LooseVersion(self.version) >= LooseVersion('3.1.1')
 
     @staticmethod
     def extra_options(extra_vars=None):
@@ -140,7 +139,7 @@ class EB_MPICH(ConfigureMake):
                 
         # Starting MPICH 3.1.1, libraries have been renamed
         # cf http://git.mpich.org/mpich.git/blob_plain/v3.1.1:/CHANGES
-        if self.use_new_libnames:
+        if self.use_new_libnames():
             libnames = ['mpi', 'mpicxx', 'mpifort']
         else:
             libnames = ['fmpich', 'mpichcxx', 'mpichf90', 'mpich', 'mpl', 'opa']

--- a/easybuild/easyblocks/m/mvapich2.py
+++ b/easybuild/easyblocks/m/mvapich2.py
@@ -34,6 +34,7 @@ EasyBuild support for building and installing the MVAPICH2 MPI library, implemen
 """
 
 import os
+from distutils.version import LooseVersion
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.mpich import EB_MPICH
@@ -47,6 +48,13 @@ class EB_MVAPICH2(EB_MPICH):
     Support for building the MVAPICH2 MPI library.
     - some compiler dependent configure options
     """
+
+    def __init__(self, *args, **kwargs):
+        """Custom constructor for EB_MVAPICH2 easyblock, initialize custom class parameters."""
+        super(EB_MVAPICH2, self).__init__(*args, **kwargs)        
+        # MVAPICH2 >=2.1 depends on MPICH >=3.1.1, which uses new library names
+        # cf http://git.mpich.org/mpich.git/blob_plain/v3.1.1:/CHANGES
+        self.use_new_libnames = LooseVersion(self.version) >= LooseVersion('2.1')
 
     @staticmethod
     def extra_options():
@@ -115,6 +123,6 @@ class EB_MVAPICH2(EB_MPICH):
         Custom sanity check for MVAPICH2
         """
         custom_paths = {
-            'files': ['bin/%s' % x for x in ['mpiexec.hydra']] 
+            'files': ['bin/%s' % x for x in ['mpiexec.mpirun_rsh']] 
         }
         super(EB_MVAPICH2, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/m/mvapich2.py
+++ b/easybuild/easyblocks/m/mvapich2.py
@@ -49,12 +49,11 @@ class EB_MVAPICH2(EB_MPICH):
     - some compiler dependent configure options
     """
 
-    def __init__(self, *args, **kwargs):
-        """Custom constructor for EB_MVAPICH2 easyblock, initialize custom class parameters."""
-        super(EB_MVAPICH2, self).__init__(*args, **kwargs)        
-        # MVAPICH2 >=2.1 depends on MPICH >=3.1.1, which uses new library names
+    def use_new_libnames(self):
+        """Tell if the underlying MPICH use the new names for its libraries"""
         # cf http://git.mpich.org/mpich.git/blob_plain/v3.1.1:/CHANGES
-        self.use_new_libnames = LooseVersion(self.version) >= LooseVersion('2.1')
+        # MVAPICH2 2.1 is based on MPICH 3.1.4
+        return LooseVersion(self.version) >= LooseVersion('2.1')
 
     @staticmethod
     def extra_options():

--- a/easybuild/easyblocks/m/mvapich2.py
+++ b/easybuild/easyblocks/m/mvapich2.py
@@ -31,6 +31,7 @@ EasyBuild support for building and installing the MVAPICH2 MPI library, implemen
 @author: Pieter De Baets (Ghent University)
 @author: Jens Timmerman (Ghent University)
 @author: Damian Alvarez (Forschungszentrum Juelich)
+@author: Xavier Besseron (University of Luxembourg)
 """
 
 import os

--- a/easybuild/easyblocks/m/mvapich2.py
+++ b/easybuild/easyblocks/m/mvapich2.py
@@ -77,23 +77,6 @@ class EB_MVAPICH2(EB_MPICH):
         add_configopts = []
         add_configopts.append('--with-rdma=%s' % self.cfg['rdma_type'])
 
-        # use POSIX threads
-        add_configopts.append('--with-thread-package=pthreads')
-
-        if self.cfg['debug']:
-            # debug build, with error checking, timing and debug info
-            # note: this will affact performance
-            add_configopts.append('--enable-fast=none')
-        else:
-            # optimized build, no error checking, timing or debug info
-            add_configopts.append('--enable-fast')
-
-        # enable shared libraries, using GCC and GNU ld options
-        add_configopts.extend(['--enable-shared', '--enable-sharedlibs=gcc'])
-
-        # enable Fortran 77/90 and C++ bindings
-        add_configopts.extend(['--enable-f77', '--enable-fc', '--enable-cxx'])
-
         # enable specific support options (if desired)
         if self.cfg['withmpe']:
             add_configopts.append('--enable-mpe')

--- a/easybuild/easyblocks/m/mvapich2.py
+++ b/easybuild/easyblocks/m/mvapich2.py
@@ -33,6 +33,7 @@ EasyBuild support for building and installing the MVAPICH2 MPI library, implemen
 """
 
 import os
+from distutils.version import LooseVersion
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
@@ -134,10 +135,14 @@ class EB_MVAPICH2(ConfigureMake):
         Custom sanity check for MVAPICH2
         """
         shlib_ext = get_shared_lib_ext()
-        custom_paths = {
-            'files': ['bin/%s' % x for x in ['mpicc', 'mpicxx', 'mpif77', 'mpif90', 'mpiexec.hydra']] +
-                     ['lib/lib%s' % y for x in ['fmpich', 'mpichcxx', 'mpichf90', 'mpich', 'mpl', 'opa']
-                                      for y in ['%s.a' % x, '%s.%s' % (x, shlib_ext)]],
-            'dirs': ['include'],
-        }
+        binaries = ['bin/%s' % x for x in ['mpicc', 'mpicxx', 'mpif77', 'mpif90', 'mpiexec.hydra']]
+        directories = ['include']
+        if LooseVersion(self.version) < LooseVersion('2.1'):
+            libraries = ['lib/lib%s' % y for x in ['fmpich', 'mpichcxx', 'mpichf90', 'mpich', 'mpl', 'opa']
+                                      for y in ['%s.a' % x, '%s.%s' % (x, shlib_ext)]]
+        else:
+            libraries = ['lib/lib%s' % y for x in ['mpi', 'mpicxx', 'mpifort']
+                                      for y in ['%s.a' % x, '%s.%s' % (x, shlib_ext)]]
+            
+        custom_paths = { 'files': binaries + libraries,  'dirs': directories }
         super(EB_MVAPICH2, self).sanity_check_step(custom_paths=custom_paths)


### PR DESCRIPTION
MVAPICH2 library names have changed since version 2.1.
These changes in the library names are inherited from MPICH 3.1.1 and above.
cf http://git.mpich.org/mpich.git/blob_plain/v3.1.1:/CHANGES

