### PR TITLE
Remove deprecated configure options from MVAPICH2 easyblock

### DIFF
--- a/easybuild/easyblocks/m/mvapich2.py
+++ b/easybuild/easyblocks/m/mvapich2.py
@@ -51,6 +51,7 @@ class EB_MVAPICH2(EB_MPICH):
         """Define custom easyconfig parameters specific to MVAPICH2."""
         extra_vars = {
             'withchkpt': [False, "Enable checkpointing support (required BLCR)", CUSTOM],
+            'withmpe': [False, "Build MPE routines", CUSTOM],
             'withlimic2': [False, "Enable LiMIC2 support for intra-node communication", CUSTOM],
             'rdma_type': ["gen2", "Specify the RDMA type (gen2/udapl)", CUSTOM],
             'blcr_path': [None, "Path to BLCR package", CUSTOM],
@@ -67,6 +68,15 @@ class EB_MVAPICH2(EB_MPICH):
         add_configopts.append('--with-rdma=%s' % self.cfg['rdma_type'])
 
         # enable specific support options (if desired)
+        if self.cfg['withmpe']:
+            # --enable-mpe is coming from MPICH.
+            # It is not available anymore in MPICH package since version 3.0, which correspond to MVAPICH2 1.9.
+            # MPE can be downloaded separately at http://www.mpich.org/static/mpe/downloads/
+            # However, the 'withmpe' option should be maintained for backward compatibility purpose
+            if LooseVersion(self.version) < LooseVersion('1.9'):
+                add_configopts.append('--enable-mpe')
+            else:
+                raise EasyBuildError("MPI Parallel Environment (MPE) is not available anymore starting MVAPICH2 1.9")
         if self.cfg['withlimic2']:
             add_configopts.append('--enable-limic2')
         if self.cfg['withchkpt']:

--- a/easybuild/easyblocks/m/mvapich2.py
+++ b/easybuild/easyblocks/m/mvapich2.py
@@ -71,7 +71,7 @@ class EB_MVAPICH2(EB_MPICH):
 
         # enable specific support options (if desired)
         if self.cfg['withmpe']:
-            # --enable-mpe is coming from MPICH.
+            # --enable-mpe is a configure option of MPICH itself.
             # It is not available anymore in MPICH package since version 3.0, which correspond to MVAPICH2 1.9.
             # MPE can be downloaded separately at http://www.mpich.org/static/mpe/downloads/
             # However, the 'withmpe' option should be maintained for backward compatibility purpose

--- a/easybuild/easyblocks/m/mvapich2.py
+++ b/easybuild/easyblocks/m/mvapich2.py
@@ -52,6 +52,7 @@ class EB_MVAPICH2(EB_MPICH):
         extra_vars = {
             'withchkpt': [False, "Enable checkpointing support (required BLCR)", CUSTOM],
             'withmpe': [False, "Build MPE routines", CUSTOM],
+            'withhwloc': [False, "Enable support for using hwloc support for process binding", CUSTOM],
             'withlimic2': [False, "Enable LiMIC2 support for intra-node communication", CUSTOM],
             'rdma_type': ["gen2", "Specify the RDMA type (gen2/udapl)", CUSTOM],
             'blcr_path': [None, "Path to BLCR package", CUSTOM],
@@ -81,6 +82,13 @@ class EB_MVAPICH2(EB_MPICH):
             add_configopts.append('--enable-limic2')
         if self.cfg['withchkpt']:
             add_configopts.extend(['--enable-checkpointing', '--with-hydra-ckpointlib=blcr'])
+        if self.cfg['withhwloc']:
+            # --with-hwloc/--without-hwloc option is not available anymore MVAPICH2 >= 2.0.
+            # Starting this version, HWLOC is apparently distributed with MVAPICH2 and always compiled with MVAPICH2,
+            # and it cannot be disabled.
+            # The 'withhwloc' option should be maintained for backward compatibility purpose.
+            # EasyBuild and MVAPCH2 will just silently ignore this option if it is used.
+            add_configopts.append('--with-hwloc')
 
         # pass BLCR paths if specified
         if self.cfg['blcr_path']:

--- a/easybuild/easyblocks/m/mvapich2.py
+++ b/easybuild/easyblocks/m/mvapich2.py
@@ -69,8 +69,6 @@ class EB_MVAPICH2(EB_MPICH):
         add_configopts.append('--with-rdma=%s' % self.cfg['rdma_type'])
 
         # enable specific support options (if desired)
-        if self.cfg['withmpe']:
-            add_configopts.append('--enable-mpe')
         if self.cfg['withlimic2']:
             add_configopts.append('--enable-limic2')
         if self.cfg['withchkpt']:

--- a/easybuild/easyblocks/m/mvapich2.py
+++ b/easybuild/easyblocks/m/mvapich2.py
@@ -51,8 +51,6 @@ class EB_MVAPICH2(EB_MPICH):
         """Define custom easyconfig parameters specific to MVAPICH2."""
         extra_vars = {
             'withchkpt': [False, "Enable checkpointing support (required BLCR)", CUSTOM],
-            'withmpe': [False, "Build MPE routines", CUSTOM],
-            'withhwloc': [False, "Enable support for using hwloc support for process binding", CUSTOM],
             'withlimic2': [False, "Enable LiMIC2 support for intra-node communication", CUSTOM],
             'rdma_type': ["gen2", "Specify the RDMA type (gen2/udapl)", CUSTOM],
             'blcr_path': [None, "Path to BLCR package", CUSTOM],
@@ -73,8 +71,6 @@ class EB_MVAPICH2(EB_MPICH):
             add_configopts.append('--enable-limic2')
         if self.cfg['withchkpt']:
             add_configopts.extend(['--enable-checkpointing', '--with-hydra-ckpointlib=blcr'])
-        if self.cfg['withhwloc']:
-            add_configopts.append('--with-hwloc')
 
         # pass BLCR paths if specified
         if self.cfg['blcr_path']:

--- a/easybuild/easyblocks/m/mvapich2.py
+++ b/easybuild/easyblocks/m/mvapich2.py
@@ -52,7 +52,7 @@ class EB_MVAPICH2(EB_MPICH):
         extra_vars = {
             'withchkpt': [False, "Enable checkpointing support (required BLCR)", CUSTOM],
             'withmpe': [False, "Build MPE routines", CUSTOM],
-            'withhwloc': [False, "Enable support for using hwloc support for process binding", CUSTOM],
+            'withhwloc': [True, "Enable support for using hwloc support for process binding", CUSTOM],
             'withlimic2': [False, "Enable LiMIC2 support for intra-node communication", CUSTOM],
             'rdma_type': ["gen2", "Specify the RDMA type (gen2/udapl)", CUSTOM],
             'blcr_path': [None, "Path to BLCR package", CUSTOM],


### PR DESCRIPTION
MVAPICH2 easyblock uses some deprecated configure options:
- `--enable-mpe` disappeared starting version >= 1.9
- `--enable-hwloc` disappeared starting version >= 2.0

This PR removes these deprecated options from the easyblock. 
PR https://github.com/hpcugent/easybuild-easyconfigs/pull/2626 for easyconfigs set these options directly in the easyconfig files when there are used.

PR https://github.com/hpcugent/easybuild-easyconfigs/pull/2626 have to be merged first.
