### PR TITLE
Use correct configure option for checkpoint/restart in MVAPICH2 easyblock

### DIFF
--- a/easybuild/easyblocks/m/mvapich2.py
+++ b/easybuild/easyblocks/m/mvapich2.py
@@ -96,8 +96,12 @@ class EB_MVAPICH2(EB_MPICH):
         """
         Custom sanity check for MVAPICH2
         """
+        mv2_bins = ['bin/mpiexec.mpirun_rsh']
+        if self.cfg['withchkpt']:
+            mv2_bins += ['bin/mv2_checkpoint']
+
         custom_paths = {
-            'files': ['bin/mpiexec.mpirun_rsh'],
+            'files': mv2_bins,
         }
 
         # cfr. http://git.mpich.org/mpich.git/blob_plain/v3.1.1:/CHANGES

--- a/easybuild/easyblocks/m/mvapich2.py
+++ b/easybuild/easyblocks/m/mvapich2.py
@@ -74,7 +74,7 @@ class EB_MVAPICH2(EB_MPICH):
         if self.cfg['withlimic2']:
             add_configopts.append('--enable-limic2')
         if self.cfg['withchkpt']:
-            add_configopts.extend(['--enable-checkpointing', '--with-hydra-ckpointlib=blcr'])
+            add_configopts.extend(['--enable-ckpt'])
         if self.cfg['withhwloc']:
             add_configopts.append('--with-hwloc')
 


### PR DESCRIPTION
MVAPICH2 easyblock uses the wrong configure options to enable the checkpoint/restart support. It uses the options from MPICH instead of the one from MVAPICH2. As a result, I'm pretty sure that the checkpoint/restart is not working properly with this build.

The issue with this change is that the result of the build will be different. However, this affect only one easyconfig file `MVAPICH2-1.7-GCC-4.6.3-hwloc-chkpt.eb`. 

For reference:
- Checkpoint/Restart support in MVAPICH2:
http://mvapich.cse.ohio-state.edu/static/media/mvapich/mvapich2-2.2b-userguide.html#x1-120004.4
- Checkpoint/Restart support in MPICH:
https://wiki.mpich.org/mpich/index.php/Checkpointing
