### PR TITLE
Easyblock for mutil + MakeCp enhancement.

### DIFF
--- a/easybuild/easyblocks/generic/makecp.py
+++ b/easybuild/easyblocks/generic/makecp.py
@@ -95,7 +95,7 @@ class MakeCp(ConfigureMake):
                 if not os.path.exists(target):
                     os.makedirs(target)
 
-                for files_spec in files_specs:
+                for idx, files_spec in enumerate(files_specs):
                     # first look for files in start dir
                     filepaths = glob.glob(os.path.join(self.cfg['start_dir'], files_spec))
                     tup = (files_spec, self.cfg['start_dir'], filepaths)
@@ -112,7 +112,11 @@ class MakeCp(ConfigureMake):
                     if not filepaths:
                         raise EasyBuildError("No files matching '%s' found anywhere.", files_spec)
 
-                    for idx, filepath in enumerate(filepaths):
+                    if new_names and len(filepaths) != 1:
+                        raise EasyBuildError("When a list with new names has been specified, the original file spec can \
+                                             only match a single file yet it gives: %s", filepaths)
+
+                    for filepath in filepaths:
                         # copy individual file
                         if os.path.isfile(filepath):
                             if new_names:

--- a/easybuild/easyblocks/generic/makecp.py
+++ b/easybuild/easyblocks/generic/makecp.py
@@ -118,11 +118,11 @@ class MakeCp(ConfigureMake):
                     for filepath in filepaths:
                         # copy individual file
                         if os.path.isfile(filepath):
-                            self.log.debug("Copying file %s to %s" % (filepath, dest))
                             if dest:
                                 target_dest = os.path.join(target, dest)
                             else:
                                 target_dest = target
+                            self.log.debug("Copying file %s to %s" % (filepath, target_dest))
                             shutil.copy2(filepath, target_dest)
                         # copy directory
                         elif os.path.isdir(filepath):

--- a/easybuild/easyblocks/generic/makecp.py
+++ b/easybuild/easyblocks/generic/makecp.py
@@ -95,8 +95,6 @@ class MakeCp(ConfigureMake):
                         files_spec = orig_files_spec
                         dest = None
 
-                    self.log.debug("Found: %s to %s", files_spec, dest)
-
                     # first look for files in start dir
                     filepaths = glob.glob(os.path.join(self.cfg['start_dir'], files_spec))
                     tup = (files_spec, self.cfg['start_dir'], filepaths)

--- a/easybuild/easyblocks/generic/makecp.py
+++ b/easybuild/easyblocks/generic/makecp.py
@@ -74,9 +74,17 @@ class MakeCp(ConfigureMake):
                     # ([src1, src2], targetdir)
                     if len(fil) == 2 and isinstance(fil[0], list) and isinstance(fil[1], basestring):
                         files_specs = fil[0]
+                        new_names = None
                         target = os.path.join(self.installdir, fil[1])
+                    # ([src1, src2], [src1_new, src2_new], targetdir)
+                    elif len(fil) == 3 and isinstance(fil[0], list) and isinstance(fil[0], list) and \
+                            len(fil[0]) == len(fil[1]) and isinstance(fil[2], basestring):
+                        files_specs = fil[0]
+                        new_names = fil[1]
+                        target = os.path.join(self.installdir, fil[2])
                     else:
-                        raise EasyBuildError("Only tuples of format '([<source files>], <target dir>)' supported.")
+                        raise EasyBuildError("Only tuples of format '([<source files>], <target dir>)' or \
+                                              '([<source files>], [<new name files>], <target dir>)' are supported.")
                 # 'src_file' or 'src_dir'
                 elif isinstance(fil, basestring):
                     files_specs = [fil]
@@ -104,11 +112,15 @@ class MakeCp(ConfigureMake):
                     if not filepaths:
                         raise EasyBuildError("No files matching '%s' found anywhere.", files_spec)
 
-                    for filepath in filepaths:
+                    for idx, filepath in enumerate(filepaths):
                         # copy individual file
                         if os.path.isfile(filepath):
-                            self.log.debug("Copying file %s to %s" % (filepath, target))
-                            shutil.copy2(filepath, target)
+                            if new_names:
+                                dest = os.path.join(target, new_names[idx])
+                            else:
+                                dest = target
+                            self.log.debug("Copying file %s to %s" % (filepath, dest))
+                            shutil.copy2(filepath, dest)
                         # copy directory
                         elif os.path.isdir(filepath):
                             self.log.debug("Copying directory %s to %s" % (filepath, target))

--- a/easybuild/easyblocks/m/mutil.py
+++ b/easybuild/easyblocks/m/mutil.py
@@ -1,0 +1,63 @@
+##
+# Copyright 2016-2016 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://vscentrum.be/nl/en),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# http://github.com/hpcugent/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for mutil, implemented as an easyblock
+
+@author: Ward Poelmans (Ghent University)
+"""
+import re
+import os
+
+from easybuild.easyblocks.generic.makecp import MakeCp
+from easybuild.tools.build_log import EasyBuildError
+
+
+class EB_mutil(MakeCp):
+    """Class to build mutil"""
+
+    def __init__(self, *args, **kwargs):
+        """Easyblock constructor, set correct options"""
+        super(EB_mutil, self).__init__(*args, **kwargs)
+
+        self.cfg['with_configure'] = True
+
+    def extract_step(self):
+        """Set the start dir correctly and add patch from source."""
+        super(EB_mutil, self).extract_step()
+
+        # 1.822.3 -> 8.22
+        coreutils_version = re.sub(r"^\d+.(\d+)(\d\d).\d+", r"\1.\2", self.version)
+        coreutils_patch = "coreutils-%s.patch" % coreutils_version
+        patch_path = os.path.join(self.builddir, "%s-%s" % (self.name, self.version), "patch", coreutils_patch)
+        if not os.path.isfile(patch_path):
+            raise EasyBuildError("Could not find the patch for coreutils: %s", coreutils_patch)
+
+        # add the extract patch to the list of patches
+        newpatch = {
+            'name': coreutils_patch,
+            'path': patch_path,
+            'checksum': None,
+        }
+        self.patches.insert(0, newpatch)


### PR DESCRIPTION
For the `MakeCp` block you can now specify:
```python
files_to_copy = [(['oldname1','oldname2'], ['newname1','newname2'], 'target-dir')]
```

@boegel please review