### PR TITLE
hunt for usable 'python' command in PythonPackage easyblock when system Python is used

### DIFF
--- a/easybuild/easyblocks/generic/configuremakepythonpackage.py
+++ b/easybuild/easyblocks/generic/configuremakepythonpackage.py
@@ -55,7 +55,7 @@ class ConfigureMakePythonPackage(ConfigureMake, PythonPackage):
     def configure_step(self, *args, **kwargs):
         """Configure build using 'python configure'."""
         PythonPackage.configure_step(self, *args, **kwargs)
-        cmd = "%s python %s" % (self.cfg['preconfigopts'], self.cfg['configopts'])
+        cmd = ' '.join([self.cfg['preconfigopts'], self.python_cmd, self.cfg['configopts']])
         run_cmd(cmd, log_all=True)
 
     def build_step(self, *args, **kwargs):

--- a/easybuild/easyblocks/generic/fortranpythonpackage.py
+++ b/easybuild/easyblocks/generic/fortranpythonpackage.py
@@ -48,7 +48,7 @@ class FortranPythonPackage(PythonPackage):
         comp_fam = self.toolchain.comp_family()
 
         if comp_fam == toolchain.INTELCOMP:  # @UndefinedVariable
-            cmd = "python setup.py build --compiler=intel --fcompiler=intelem"
+            cmd = "%s setup.py build --compiler=intel --fcompiler=intelem" % self.python_cmd
 
         elif comp_fam in [toolchain.GCC, toolchain.CLANGGCC]:  # @UndefinedVariable
             cmdprefix = ""
@@ -63,7 +63,7 @@ class FortranPythonPackage(PythonPackage):
                                                                                               ldflags,
                                                                                               cmdprefix))
 
-            cmd = "%s python setup.py build --fcompiler=gnu95" % cmdprefix
+            cmd = "%s %s setup.py build --fcompiler=gnu95" % (cmdprefix, self.python_cmd)
 
         else:
             raise EasyBuildError("Unknown family of compilers being used: %s", comp_fam)

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -254,14 +254,18 @@ class PythonPackage(ExtensionEasyBlock):
     def prepare_python(self):
         """Python-specific preperations."""
         # pick 'python' command to use
+        python = None
+
         python_root = get_software_root('Python')
         # keep in mind that Python may be listed as an allowed system dependency,
         # so just checking Python root is not sufficient
-        bin_python = os.path.join(python_root, 'bin', 'python')
-        if python_root and os.path.exists(bin_python) and os.path.samefile(which('python'), bin_python):
-            # if Python is listed as a (build) dependency, use 'python' command provided that way
-            python = os.path.join(python_root, 'bin', 'python')
-        else:
+        if python_root:
+            bin_python = os.path.join(python_root, 'bin', 'python')
+            if os.path.exists(bin_python) and os.path.samefile(which('python'), bin_python):
+                # if Python is listed as a (build) dependency, use 'python' command provided that way
+                python = os.path.join(python_root, 'bin', 'python')
+
+        if python is None:
             # if using system Python, go hunting for a 'python' command that satisfies the requirements
             python = pick_python_cmd(req_maj_ver=self.cfg['req_py_majver'], req_min_ver=self.cfg['req_py_minver'])
 

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -128,7 +128,7 @@ def pick_python_cmd(req_maj_ver=None, req_min_ver=None):
                 res = python_cmd
             else:
                 res = which(python_cmd)
-            log.debug("Absolute path to retained Python command: %s", python_cmd)
+            log.debug("Absolute path to retained Python command: %s", res)
             break
         else:
             log.debug("Python command '%s' does not satisfy version requirements (maj: %s, min: %s), moving on",
@@ -292,7 +292,7 @@ class PythonPackage(ExtensionEasyBlock):
 
         # mainly for debugging
         if self.install_cmd.startswith(EASY_INSTALL_INSTALL_CMD):
-            run_cmd("python setup.py easy_install --version", verbose=False)
+            run_cmd("%s setup.py easy_install --version" % self.python_cmd, verbose=False)
         if self.install_cmd.startswith(PIP_INSTALL_CMD):
             out, _ = run_cmd("pip --version", verbose=False, simple=False)
 

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -257,7 +257,8 @@ class PythonPackage(ExtensionEasyBlock):
         python_root = get_software_root('Python')
         # keep in mind that Python may be listed as an allowed system dependency,
         # so just checking Python root is not sufficient
-        if python_root and os.path.samefile(which('python'), os.path.join(python_root, 'bin', 'python')):
+        bin_python = os.path.join(python_root, 'bin', 'python')
+        if python_root and os.path.exists(bin_python) and os.path.samefile(which('python'), bin_python):
             # if Python is listed as a (build) dependency, use 'python' command provided that way
             python = os.path.join(python_root, 'bin', 'python')
         else:

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -89,7 +89,7 @@ def pick_python_cmd(req_maj_ver=None, req_min_ver=None):
             else:
                 req_majmin_ver = '%s.%s' % (req_maj_ver, req_min_ver)
 
-            pycode = 'import sys; print "%s.%s" % sys.version_info[:2]'
+            pycode = 'import sys; print("%s.%s" % sys.version_info[:2])'
             out, _ = run_cmd("%s -c '%s'" % (python_cmd, pycode), simple=False)
 
             # (strict) check for major version

--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -393,7 +393,7 @@ class PythonPackage(ExtensionEasyBlock):
         if isinstance(self.cfg['runtest'], basestring):
             self.testcmd = self.cfg['runtest']
 
-        if self.cfg['runtest'] and not self.testcmd is None:
+        if self.cfg['runtest'] and self.testcmd is not None:
             extrapath = ""
             testinstalldir = None
 
@@ -417,7 +417,7 @@ class PythonPackage(ExtensionEasyBlock):
                 run_cmd(cmd, log_all=True, simple=True, verbose=False)
 
             if self.testcmd:
-                cmd = "%s%s" % (extrapath, self.testcmd)
+                cmd = "%s%s" % (extrapath, self.testcmd % {'python': self.python_cmd})
                 run_cmd(cmd, log_all=True, simple=True)
 
             if testinstalldir:
@@ -466,8 +466,10 @@ class PythonPackage(ExtensionEasyBlock):
         """
         Custom sanity check for Python packages
         """
-        if not 'exts_filter' in kwargs:
-            kwargs.update({'exts_filter': EXTS_FILTER_PYTHON_PACKAGES})
+        if 'exts_filter' not in kwargs:
+            orig_exts_filter = EXTS_FILTER_PYTHON_PACKAGES
+            exts_filter = (orig_exts_filter[0].replace('python', self.python_cmd), orig_exts_filter[1])
+            kwargs.update({'exts_filter': exts_filter})
         return super(PythonPackage, self).sanity_check_step(*args, **kwargs)
 
     def make_module_req_guess(self):

--- a/easybuild/easyblocks/generic/vscpythonpackage.py
+++ b/easybuild/easyblocks/generic/vscpythonpackage.py
@@ -45,6 +45,6 @@ class VSCPythonPackage(VersionIndependentPythonPackage):
         """Custom sanity check for VSC-tools packages."""
         pythonpath = os.environ.get('PYTHONPATH', '')
         os.environ['PYTHONPATH'] = ''
-        kwargs.update({'exts_filter': ('python -s -S -c "import %(ext_name)s"', "")})
+        kwargs.update({'exts_filter': ('%s -s -S -c "import %%(ext_name)s"' % self.python_cmd, "")})
         super(VSCPythonPackage, self).sanity_check_step(*args, **kwargs)
         os.environ['PYTHONPATH'] = pythonpath

--- a/easybuild/easyblocks/l/libxml2.py
+++ b/easybuild/easyblocks/l/libxml2.py
@@ -58,8 +58,8 @@ class EB_libxml2(ConfigureMake, PythonPackage):
         # We will do the python bindings ourselves so force them off
         self.cfg.update('configopts', '--without-python')
         ConfigureMake.configure_step(self)
-        # make sure self.all_pylibdirs is defined properly
-        PythonPackage.set_pylibdirs(self)
+        # prepare for installing Python package
+        PythonPackage.prepare_python(self)
 
     def build_step(self):
         """

--- a/easybuild/easyblocks/n/netcdf4_python.py
+++ b/easybuild/easyblocks/n/netcdf4_python.py
@@ -64,7 +64,7 @@ class EB_netcdf4_minus_python(PythonPackage):
         """Run netcdf4-python tests."""
         self.testinstall = True
         cwd = os.getcwd()
-        self.testcmd = "cd %s/test && python run_all.py && cd %s" % (self.cfg['start_dir'], cwd)
+        self.testcmd = "cd %s/test && %s run_all.py && cd %s" % (self.cfg['start_dir'], self.python_cmd, cwd)
         super(EB_netcdf4_minus_python, self).test_step()
 
     def sanity_check_step(self):

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -65,18 +65,18 @@ class EB_numpy(FortranPythonPackage):
         self.sitecfgfn = 'site.cfg'
         self.installopts = ''
         self.testinstall = True
-        self.testcmd = "cd .. && python -c 'import numpy; numpy.test(verbose=2)'"
+        self.testcmd = "cd .. && %(python)s -c 'import numpy; numpy.test(verbose=2)'"
 
     def configure_step(self):
         """Configure numpy build by composing site.cfg contents."""
 
         # see e.g. https://github.com/numpy/numpy/pull/2809/files
         self.sitecfg = '\n'.join([
-                "[DEFAULT]",
-                "library_dirs = %(libs)s",
-                "include_dirs= %(includes)s",
-                "search_static_first=True",
-            ])
+            "[DEFAULT]",
+            "library_dirs = %(libs)s",
+            "include_dirs= %(includes)s",
+            "search_static_first=True",
+        ])
 
         if get_software_root("imkl"):
 
@@ -208,7 +208,7 @@ class EB_numpy(FortranPythonPackage):
         super(EB_numpy, self).configure_step()
 
         # check configuration (for debugging purposes)
-        cmd = "python setup.py config"
+        cmd = "%s setup.py config" % self.python_cmd
         run_cmd(cmd, log_all=True, simple=True)
 
     def test_step(self):
@@ -217,7 +217,7 @@ class EB_numpy(FortranPythonPackage):
 
         # temporarily install numpy, it doesn't alow to be used straight from the source dir
         tmpdir = tempfile.mkdtemp()
-        cmd = "python setup.py install --prefix=%s %s" % (tmpdir, self.installopts)
+        cmd = "%s setup.py install --prefix=%s %s" % (self.python_cmd, tmpdir, self.installopts)
         run_cmd(cmd, log_all=True, simple=True, verbose=False)
 
         try:
@@ -230,7 +230,7 @@ class EB_numpy(FortranPythonPackage):
         size = 1000
         cmd = ' '.join([
             'export PYTHONPATH=%s:$PYTHONPATH &&' % os.path.join(tmpdir, self.pylibdir),
-            'python -m timeit -n 3 -r 3',
+            '%s -m timeit -n 3 -r 3' % self.python_cmd,
             '-s "import numpy; x = numpy.random.random((%(size)d, %(size)d))"' % {'size': size},
             '"numpy.dot(x, x.T)"',
         ])

--- a/easybuild/easyblocks/s/scipy.py
+++ b/easybuild/easyblocks/s/scipy.py
@@ -46,7 +46,7 @@ class EB_scipy(FortranPythonPackage):
         super(EB_scipy, self).__init__(*args, **kwargs)
 
         self.testinstall = True
-        self.testcmd = "cd .. && python -c 'import numpy; import scipy; scipy.test(verbose=2)'"
+        self.testcmd = "cd .. && %(python)s -c 'import numpy; import scipy; scipy.test(verbose=2)'"
 
     def configure_step(self):
         """Custom configure step for scipy: set extra installation options when needed."""
@@ -64,5 +64,5 @@ class EB_scipy(FortranPythonPackage):
             'files': [os.path.join(self.pylibdir, 'scipy', '__init__.py')],
             'dirs': [],
         }
-        custom_commands = [('python', '-c "import scipy"')]
+        custom_commands = [(self.python_cmd, '-c "import scipy"')]
         return super(EB_scipy, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)

--- a/easybuild/easyblocks/v/vsc_tools.py
+++ b/easybuild/easyblocks/v/vsc_tools.py
@@ -65,7 +65,7 @@ class EB_VSC_minus_tools(PythonPackage):
                     raise EasyBuildError("Found none or more than one %s dir in %s: %s", pkg, self.builddir, sel_dirs)
 
                 os.chdir(os.path.join(self.builddir, sel_dirs[0]))
-                cmd = "python setup.py %s" % args
+                cmd = "%s setup.py %s" % (self.python_cmd, args)
                 run_cmd(cmd, log_all=True, simple=True, log_output=True)
 
             os.chdir(pwd)
@@ -77,13 +77,13 @@ class EB_VSC_minus_tools(PythonPackage):
         """Custom sanity check for VSC-tools."""
 
         custom_paths = {
-                        'files': ['bin/%s' % x for x in ['ihmpirun', 'impirun', 'logdaemon', 'm2hmpirun',
-                                                         'm2mpirun', 'mhmpirun', 'mmmpirun', 'mmpirun',
-                                                         'mympirun', 'mympisanity', 'myscoop', 'ompirun',
-                                                         'pbsssh', 'qmpirun', 'sshsleep', 'startlogdaemon',
-                                                         'fake/mpirun']],
-                        'dirs': ['lib'],
-                       }
+            'files': ['bin/%s' % x for x in ['ihmpirun', 'impirun', 'logdaemon', 'm2hmpirun',
+                                             'm2mpirun', 'mhmpirun', 'mmmpirun', 'mmpirun',
+                                             'mympirun', 'mympisanity', 'myscoop', 'ompirun',
+                                             'pbsssh', 'qmpirun', 'sshsleep', 'startlogdaemon',
+                                             'fake/mpirun']],
+            'dirs': ['lib'],
+        }
 
         super(EB_VSC_minus_tools, self).sanity_check_step(custom_paths=custom_paths)
 

--- a/test/easyblocks/module.py
+++ b/test/easyblocks/module.py
@@ -31,6 +31,7 @@ Unit tests to check that easyblocks are compatible with --module-only.
 import glob
 import os
 import re
+import sys
 import tempfile
 from vsc.utils import fancylogger
 from unittest import TestLoader, main
@@ -143,6 +144,20 @@ class ModuleOnlyTest(EnhancedTestCase):
 
             self.assertEqual(bool(regex.search(modtxt)), found, assert_msg)
 
+    def test_pythonpackage_det_pylibdir(self):
+        """Test det_pylibdir function from pythonpackage.py."""
+        from easybuild.easyblocks.generic.pythonpackage import det_pylibdir
+        for pylibdir in [det_pylibdir(), det_pylibdir(plat_specific=True), det_pylibdir(python_cmd=sys.executable)]:
+            self.assertTrue(pylibdir.startswith('lib') and '/python' in pylibdir and pylibdir.endswith('site-packages'))
+
+    def test_pythonpackage_pick_python_cmd(self):
+        """Test pick_python_cmd function from pythonpackage.py."""
+        from easybuild.easyblocks.generic.pythonpackage import pick_python_cmd
+        self.assertTrue(pick_python_cmd() is not None)
+        self.assertTrue(pick_python_cmd(2) is not None)
+        self.assertTrue(pick_python_cmd(2, 6) is not None)
+        self.assertTrue(pick_python_cmd(123, 456) is None)
+
     def tearDown(self):
         """Cleanup."""
         try:
@@ -200,6 +215,7 @@ def template_module_only_test(self, easyblock, name='foo', version='1.3.2', extr
         os.remove(app.logfile)
     else:
         self.assertTrue(False, "Class found in easyblock %s" % easyblock)
+
 
 def suite():
     """Return all easyblock --module-only tests."""


### PR DESCRIPTION
This is required to fix the problem with bootstrapping EasyBuild in an environment where Python 3.x is the default `python`, and where `python2` is also available.