### PR TITLE
change suffix of original file to .easybuild when using fileinput in impi easyblock

### DIFF
--- a/easybuild/easyblocks/i/impi.py
+++ b/easybuild/easyblocks/i/impi.py
@@ -134,11 +134,11 @@ EULA=accept
         if impiver == LooseVersion('4.1.1.036') or impiver >= LooseVersion('5.0.1.035'):
             # fix broken env scripts after the move
             for script in [os.path.join('intel64', 'bin', 'mpivars.csh'), os.path.join('mic', 'bin', 'mpivars.csh')]:
-                for line in fileinput.input(os.path.join(self.installdir, script), inplace=1, backup='.orig.eb'):
+                for line in fileinput.input(os.path.join(self.installdir, script), inplace=1, backup='.orig.easybuild'):
                     line = re.sub(r"^setenv I_MPI_ROOT.*", "setenv I_MPI_ROOT %s" % self.installdir, line)
                     sys.stdout.write(line)
             for script in [os.path.join('intel64', 'bin', 'mpivars.sh'), os.path.join('mic', 'bin', 'mpivars.sh')]:
-                for line in fileinput.input(os.path.join(self.installdir, script), inplace=1, backup='.orig.eb'):
+                for line in fileinput.input(os.path.join(self.installdir, script), inplace=1, backup='.orig.easybuild'):
                     line = re.sub(r"^I_MPI_ROOT=.*", "I_MPI_ROOT=%s; export I_MPI_ROOT" % self.installdir, line)
                     sys.stdout.write(line)
 


### PR DESCRIPTION
The .eb extension is a bad choice because it actually means something