### PR TITLE
fix test_step in UFC easyblock

### DIFF
--- a/easybuild/easyblocks/u/ufc.py
+++ b/easybuild/easyblocks/u/ufc.py
@@ -79,6 +79,12 @@ class EB_UFC(CMakePythonPackage):
 
         super(EB_UFC, self).configure_step()
 
+    def test_step(self):
+        """No test suite available for UFC."""
+        # PythonPackage defines 'runtest' as 'True' by default, but ConfigureMake.test_step expects string value
+        # no test suite available anyway for UFC, so just pass through
+        pass
+
     def sanity_check_step(self):
         """Custom sanity check for UFC."""
         custom_paths = {


### PR DESCRIPTION
the UFC easyblock has been broken for a while (since #698 got merged), but this was not considered a big issue since UFC is deprecated (cfr. https://bitbucket.org/fenics-project/ufc-deprecated)

however, since the fix is pretty trivial...