### PR TITLE
make PythonPackage easyblock compatible with --module-only

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -343,11 +343,13 @@ class PythonPackage(ExtensionEasyBlock):
         super(PythonPackage, self).prerun()
         self.prepare_python()
 
+    def prepare_step(self):
+        """Prepare for building and installing this Python package."""
+        super(PythonPackage, self).prepare_step()
+        self.prepare_python()
+
     def configure_step(self):
         """Configure Python package build/install."""
-
-        # prepare for installing Python package
-        self.prepare_python()
 
         if self.sitecfg is not None:
             # used by some extensions, like numpy, to find certain libs

--- a/easybuild/easyblocks/l/libxml2.py
+++ b/easybuild/easyblocks/l/libxml2.py
@@ -41,6 +41,13 @@ from easybuild.tools.systemtools import get_shared_lib_ext
 
 class EB_libxml2(ConfigureMake, PythonPackage):
     """Support for building and installing libxml2 with python bindings"""
+
+    @staticmethod
+    def extra_options(extra_vars=None):
+        """Easyconfig parameters specific to libxml2."""
+        extra_vars = ConfigureMake.extra_options()
+        return PythonPackage.extra_options(extra_vars=extra_vars)
+
     def __init__(self, *args, **kwargs):
         """
         Constructor


### PR DESCRIPTION
When using `--module-only`, the `configure_step` is skipped, resulting in `self.python_cmd` not being defined.

This leads to an error like:

```
== temporary log file in case of crash /tmp/eb-D0fij6/easybuild-zoU8DE.log
== processing EasyBuild easyconfig /vscmnt/gent_vulpix/_/user/data/gent/gvo000/gvo00002/vsc40023/wxPython-3.0.2.0-intel-2016-Python-2.7.11.eb
== building and installing wxPython/3.0.2.0-intel-2016a-Python-2.7.11...
== fetching files [skipped]
== creating build dir, resetting environment...
== unpacking [skipped]
== patching [skipped]
== preparing...
== configuring [skipped]
== building [skipped]
== testing [skipped]
== installing [skipped]
== taking care of extensions [skipped]
== postprocessing [skipped]
== sanity checking...
ERROR: Traceback (most recent call last):
  File "/user/scratchdelcatty/gent/gvo000/gvo00002/vsc40023/easybuild_easy_installed/lib/python2.6/site-packages/easybuild_framework-2.8.0dev0-py2.6.egg/easybuild/main.py", line 113
, in build_and_install_software                                                                                                                                                      
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env)
  File "/user/scratch/gent/vsc400/vsc40023/easybuild_easy_installed/lib/python2.6/site-packages/easybuild_framework-2.8.0dev0-py2.6.egg/easybuild/framework/easyblock.py", line 2292,
 in build_and_install_one                                                                                                                                                            
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/user/scratch/gent/vsc400/vsc40023/easybuild_easy_installed/lib/python2.6/site-packages/easybuild_framework-2.8.0dev0-py2.6.egg/easybuild/framework/easyblock.py", line 2208,
 in run_all_steps                                                                                                                                                                    
    self.run_step(step_name, step_methods)
  File "/user/scratch/gent/vsc400/vsc40023/easybuild_easy_installed/lib/python2.6/site-packages/easybuild_framework-2.8.0dev0-py2.6.egg/easybuild/framework/easyblock.py", line 2087,
 in run_step                                                                                                                                                                         
    step_method(self)()
  File "/tmp/eb-D0fij6/included-easyblocks/easybuild/easyblocks/wxpython.py", line 64, in sanity_check_step
    super(EB_wxPython, self).sanity_check_step(custom_paths=custom_paths)
  File "/user/scratch/gent/vsc400/vsc40023/easybuild_easy_installed/lib/python2.6/site-packages/easybuild_easyblocks-2.8.0dev0-py2.6.egg/easybuild/easyblocks/generic/pythonpackage.p
y", line 471, in sanity_check_step                                                                                                                                                   
    exts_filter = (orig_exts_filter[0].replace('python', self.python_cmd), orig_exts_filter[1])
TypeError: expected a character buffer object
```

This patch fixes the issue.