### PR TITLE
PGI: move localrc adjustments to post_install_step()

### DIFF
--- a/easybuild/easyblocks/p/pgi.py
+++ b/easybuild/easyblocks/p/pgi.py
@@ -112,6 +112,13 @@ class EB_PGI(EasyBlock):
         cmd = "%s ./install" % ' '.join(['%s=%s' % x for x in sorted(pgi_env_vars.items())])
         run_cmd(cmd, log_all=True, simple=True)
 
+    def post_install_step(self):
+        """Correct localrc file to use EB GCC"""
+        super(EB_PGI, self).post_install_step()
+
+        # reload the dependencies
+        self.load_dependency_modules()
+
         # make sure localrc uses GCC in PATH, not always the system GCC, and does not use a system g77 but gfortran
         install_abs_subdir = os.path.join(self.installdir, self.install_subdir)
         filename = os.path.join(install_abs_subdir, "bin", "makelocalrc")


### PR DESCRIPTION
Together with self.load_dependency_modules() this makes really
sure the GCC version in localrc is correct.

The problem was that when the toolchain GNU/4.9.3-2.25 was used
the GNU module was loaded during installation but the GCCcore
dependency is not for the *GCC-4.9.3-2.25* easyconfigs.