### PR TITLE
PGI: delete libnuma symbolic links in installation directory

### DIFF
--- a/easybuild/easyblocks/p/pgi.py
+++ b/easybuild/easyblocks/p/pgi.py
@@ -121,6 +121,13 @@ class EB_PGI(EasyBlock):
 
         cmd = "%s -x %s -g77 /" % (filename, install_abs_subdir)
         run_cmd(cmd, log_all=True, simple=True)
+        
+        # if an OS libnuma is NOT found, makelocalrc creates symbolic links to libpgnuma.so
+        # since we use the EB libnuma, delete those symbolic links
+        for filename in ["libnuma.so", "libnuma.so.1"]:
+            path = os.path.join(install_abs_subdir, "lib", filename)
+            if os.path.islink(path):
+                os.remove(path)
 
     def sanity_check_step(self):
         """Custom sanity check for PGI"""

--- a/easybuild/easyblocks/p/pgi.py
+++ b/easybuild/easyblocks/p/pgi.py
@@ -43,6 +43,7 @@ from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import find_flexlm_license
 from easybuild.tools.run import run_cmd
+from easybuild.tools.modules import get_software_root
 
 class EB_PGI(EasyBlock):
     """

--- a/easybuild/easyblocks/p/pgi.py
+++ b/easybuild/easyblocks/p/pgi.py
@@ -122,12 +122,13 @@ class EB_PGI(EasyBlock):
         cmd = "%s -x %s -g77 /" % (filename, install_abs_subdir)
         run_cmd(cmd, log_all=True, simple=True)
         
-        # if an OS libnuma is NOT found, makelocalrc creates symbolic links to libpgnuma.so
-        # since we use the EB libnuma, delete those symbolic links
-        for filename in ["libnuma.so", "libnuma.so.1"]:
-            path = os.path.join(install_abs_subdir, "lib", filename)
-            if os.path.islink(path):
-                os.remove(path)
+        # If an OS libnuma is NOT found, makelocalrc creates symbolic links to libpgnuma.so
+        # If we use the EB libnuma, delete those symbolic links to ensure they are not used
+        if get_software_root("numactl"):
+            for filename in ["libnuma.so", "libnuma.so.1"]:
+                path = os.path.join(install_abs_subdir, "lib", filename)
+                if os.path.islink(path):
+                    os.remove(path)
 
     def sanity_check_step(self):
         """Custom sanity check for PGI"""


### PR DESCRIPTION
If the PGI installer does NOT find an OS libnuma, makelocalrc creates
symbolic links to libpgnuma.so.
Since we use the EasyBuild libnuma, delete those symbolic links.