### PR TITLE
Score-P easyblock update (REVIEW)

### DIFF
--- a/easybuild/easyblocks/s/score_p.py
+++ b/easybuild/easyblocks/s/score_p.py
@@ -63,6 +63,7 @@ class EB_Score_minus_P(ConfigureMake):
                 toolchain.GCC: 'gcc',
                 toolchain.IBMCOMP: 'ibm',
                 toolchain.INTELCOMP: 'intel',
+                toolchain.PGI: 'pgi',
             }
             comp_fam = self.toolchain.comp_family()
             if comp_fam in comp_opts:

--- a/easybuild/easyblocks/s/score_p.py
+++ b/easybuild/easyblocks/s/score_p.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013 Ghent University
+# Copyright 2013-2016 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
@@ -73,7 +73,7 @@ class EB_Score_minus_P(ConfigureMake):
 
         # auto-detection for dependencies mostly works fine, but hard specify paths anyway to have full control
         deps = {
-            'binutils': ['--with-libbfd=%%s/%s' % get_software_libdir('binutils', fs=['libbfd.a'])],
+            'binutils': ['--with-libbfd=%s'],
             'Cube': ['--with-cube=%s/bin'],
             'CUDA': ['--with-libcudart=%s'],
             'OTF2': ['--with-otf2=%s/bin'],

--- a/easybuild/easyblocks/s/score_p.py
+++ b/easybuild/easyblocks/s/score_p.py
@@ -61,9 +61,14 @@ class EB_Score_minus_P(ConfigureMake):
         mpi_opts = {
             toolchain.INTELMPI: 'intel2',  # intel: Intel MPI v1.x (ancient); intelpoe: IBM POE MPI for Intel platforms
             toolchain.OPENMPI: 'openmpi',
-            toolchain.MPICH: 'mpich3',  # In EB terms, MPICH means MPICH 3.x; MPICH 1.x is ancient and unsupported
+            toolchain.MPICH: 'mpich3',     # In EB terms, MPICH means MPICH 3.x; MPICH 1.x is ancient and unsupported
             toolchain.MPICH2: 'mpich2',
+            toolchain.MVAPICH2: 'mpich3',  # Though MVAPICH2 is based on MPICH 3.x only since v1.9b, this setting only
+                                           # affects options passed to the MPI (Fortran) compiler wrappers.  And
+                                           # MPICH 3.x compatible options were already supported in MVAPICH2 1.7.
         }
+        # With minimal toolchains, packages using this easyblock may be built with a non-MPI toolchain (e.g., OTF2).
+        # In this case, skip passing the '--with-mpi' option.
         mpi_fam = self.toolchain.mpi_family()
         if mpi_fam is not None:
             if mpi_fam in mpi_opts:

--- a/easybuild/easyblocks/s/score_p.py
+++ b/easybuild/easyblocks/s/score_p.py
@@ -74,6 +74,7 @@ class EB_Score_minus_P(ConfigureMake):
         # auto-detection for dependencies mostly works fine, but hard specify paths anyway to have full control
         deps = {
             'binutils': ['--with-libbfd=%s'],
+            'libunwind': ['--with-libunwind=%s'],
             'Cube': ['--with-cube=%s/bin'],
             'CUDA': ['--with-libcudart=%s'],
             'OTF2': ['--with-otf2=%s/bin'],

--- a/easybuild/easyblocks/s/score_p.py
+++ b/easybuild/easyblocks/s/score_p.py
@@ -82,6 +82,7 @@ class EB_Score_minus_P(ConfigureMake):
             'PAPI': ['--with-papi-header=%s/include', '--with-papi-lib=%%s/%s' % get_software_libdir('PAPI')],
             'PDT': ['--with-pdt=%s/bin'],
             'Qt': ['--with-qt=%s'],
+            'SIONlib': ['--with-sionlib=%s/bin'],
         }
         for (dep_name, dep_opts) in deps.items():
             dep_root = get_software_root(dep_name)

--- a/easybuild/easyblocks/s/score_p.py
+++ b/easybuild/easyblocks/s/score_p.py
@@ -47,6 +47,7 @@ class EB_Score_minus_P(ConfigureMake):
         # --with-mpi=(bullxmpi|hp|ibmpoe|intel|intel2|intelpoe|lam|mpibull2|mpich|mpich2|mpich3|openmpi|
         #             platform|scali|sgimpt|sun)
         comp_opts = {
+            toolchain.DUMMY: 'gcc',  # Assume that dummy toolchain uses a system-provided GCC
             toolchain.GCC: 'gcc',
             toolchain.IBMCOMP: 'ibm',
             toolchain.INTELCOMP: 'intel',

--- a/easybuild/easyblocks/s/score_p.py
+++ b/easybuild/easyblocks/s/score_p.py
@@ -42,12 +42,13 @@ class EB_Score_minus_P(ConfigureMake):
 
     def configure_step(self, *args, **kwargs):
         """Configure Score-P build, set configure options for compiler, MPI and dependencies."""
-        # compiler and MPI suite should always be specified -- MUCH quicker and SAVER than autodetect
+        # compiler and MPI suite should always be specified -- MUCH quicker and SAFER than autodetect
         # --with-nocross-compiler-suite=(gcc|ibm|intel|pgi|studio)
         # --with-mpi=(bullxmpi|hp|ibmpoe|intel|intel2|intelpoe|lam|mpibull2|mpich|mpich2|mpich3|openmpi|
         #             platform|scali|sgimpt|sun)
         comp_opts = {
             toolchain.GCC: 'gcc',
+            toolchain.IBMCOMP: 'ibm',
             toolchain.INTELCOMP: 'intel',
         }
         comp_fam = self.toolchain.comp_family()

--- a/easybuild/easyblocks/s/score_p.py
+++ b/easybuild/easyblocks/s/score_p.py
@@ -105,8 +105,13 @@ class EB_Score_minus_P(ConfigureMake):
                                          mpi_fam, ', '.join(mpi_opts.keys()))
 
         # Auto-detection for dependencies mostly works fine, but hard specify paths anyway to have full control
+        #
+        # Notes:
+        #   - binutils: Pass include/lib directories separately, as different directory layouts may break Score-P's
+        #               configure, see https://github.com/geimer/easybuild-easyblocks/pull/4#issuecomment-219284755
         deps = {
-            'binutils': ['--with-libbfd=%s'],
+            'binutils': ['--with-libbfd-include=%s/include',
+                         '--with-libbfd-lib=%%s/%s' % get_software_libdir('binutils', fs=['libbfd.a'])],
             'libunwind': ['--with-libunwind=%s'],
             'Cube': ['--with-cube=%s/bin'],
             'CUDA': ['--with-libcudart=%s'],

--- a/easybuild/easyblocks/s/score_p.py
+++ b/easybuild/easyblocks/s/score_p.py
@@ -42,41 +42,43 @@ class EB_Score_minus_P(ConfigureMake):
 
     def configure_step(self, *args, **kwargs):
         """Configure Score-P build, set configure options for compiler, MPI and dependencies."""
-        # compiler and MPI suite should always be specified -- MUCH quicker and SAFER than autodetect
-        # --with-nocross-compiler-suite=(gcc|ibm|intel|pgi|studio)
-        # --with-mpi=(bullxmpi|hp|ibmpoe|intel|intel2|intelpoe|lam|mpibull2|mpich|mpich2|mpich3|openmpi|
-        #             platform|scali|sgimpt|sun)
-        comp_opts = {
-            toolchain.DUMMY: 'gcc',  # Assume that dummy toolchain uses a system-provided GCC
-            toolchain.GCC: 'gcc',
-            toolchain.IBMCOMP: 'ibm',
-            toolchain.INTELCOMP: 'intel',
-        }
-        comp_fam = self.toolchain.comp_family()
-        if comp_fam in comp_opts:
-            self.cfg.update('configopts', "--with-nocross-compiler-suite=%s" % comp_opts[comp_fam])
-        else:
-            raise EasyBuildError("Compiler family %s not supported yet (only: %s)",
-                                 comp_fam, ', '.join(comp_opts.keys()))
-
-        mpi_opts = {
-            toolchain.INTELMPI: 'intel2',  # intel: Intel MPI v1.x (ancient); intelpoe: IBM POE MPI for Intel platforms
-            toolchain.OPENMPI: 'openmpi',
-            toolchain.MPICH: 'mpich3',     # In EB terms, MPICH means MPICH 3.x; MPICH 1.x is ancient and unsupported
-            toolchain.MPICH2: 'mpich2',
-            toolchain.MVAPICH2: 'mpich3',  # Though MVAPICH2 is based on MPICH 3.x only since v1.9b, this setting only
-                                           # affects options passed to the MPI (Fortran) compiler wrappers.  And
-                                           # MPICH 3.x compatible options were already supported in MVAPICH2 1.7.
-        }
-        # With minimal toolchains, packages using this easyblock may be built with a non-MPI toolchain (e.g., OTF2).
-        # In this case, skip passing the '--with-mpi' option.
-        mpi_fam = self.toolchain.mpi_family()
-        if mpi_fam is not None:
-            if mpi_fam in mpi_opts:
-                self.cfg.update('configopts', "--with-mpi=%s" % mpi_opts[mpi_fam])
+        tc_fam = self.toolchain.toolchain_family()
+        if tc_fam != toolchain.CRAYPE:
+            # compiler and MPI suite should always be specified -- MUCH quicker and SAFER than autodetect
+            # --with-nocross-compiler-suite=(gcc|ibm|intel|pgi|studio)
+            # --with-mpi=(bullxmpi|hp|ibmpoe|intel|intel2|intelpoe|lam|mpibull2|mpich|mpich2|mpich3|openmpi|
+            #             platform|scali|sgimpt|sun)
+            comp_opts = {
+                toolchain.DUMMY: 'gcc',  # Assume that dummy toolchain uses a system-provided GCC
+                toolchain.GCC: 'gcc',
+                toolchain.IBMCOMP: 'ibm',
+                toolchain.INTELCOMP: 'intel',
+            }
+            comp_fam = self.toolchain.comp_family()
+            if comp_fam in comp_opts:
+                self.cfg.update('configopts', "--with-nocross-compiler-suite=%s" % comp_opts[comp_fam])
             else:
-                raise EasyBuildError("MPI family %s not supported yet (only: %s)",
-                                     mpi_fam, ', '.join(mpi_opts.keys()))
+                raise EasyBuildError("Compiler family %s not supported yet (only: %s)",
+                                     comp_fam, ', '.join(comp_opts.keys()))
+
+            mpi_opts = {
+                toolchain.INTELMPI: 'intel2',  # intel: Intel MPI v1.x (ancient); intelpoe: IBM POE MPI for Intel platforms
+                toolchain.OPENMPI: 'openmpi',
+                toolchain.MPICH: 'mpich3',     # In EB terms, MPICH means MPICH 3.x; MPICH 1.x is ancient and unsupported
+                toolchain.MPICH2: 'mpich2',
+                toolchain.MVAPICH2: 'mpich3',  # Though MVAPICH2 is based on MPICH 3.x only since v1.9b, this setting only
+                                               # affects options passed to the MPI (Fortran) compiler wrappers.  And
+                                               # MPICH 3.x compatible options were already supported in MVAPICH2 1.7.
+            }
+            # With minimal toolchains, packages using this easyblock may be built with a non-MPI toolchain (e.g., OTF2).
+            # In this case, skip passing the '--with-mpi' option.
+            mpi_fam = self.toolchain.mpi_family()
+            if mpi_fam is not None:
+                if mpi_fam in mpi_opts:
+                    self.cfg.update('configopts', "--with-mpi=%s" % mpi_opts[mpi_fam])
+                else:
+                    raise EasyBuildError("MPI family %s not supported yet (only: %s)",
+                                         mpi_fam, ', '.join(mpi_opts.keys()))
 
         # auto-detection for dependencies mostly works fine, but hard specify paths anyway to have full control
         deps = {

--- a/easybuild/easyblocks/s/score_p.py
+++ b/easybuild/easyblocks/s/score_p.py
@@ -23,7 +23,8 @@
 # along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
 ##
 """
-EasyBuild support for software using the Score-P configuration style, implemented as an easyblock
+EasyBuild support for software using the Score-P configuration style (e.g., Cube, OTF2, Scalasca, and Score-P),
+implemented as an easyblock.
 
 @author: Kenneth Hoste (Ghent University)
 @author: Bernd Mohr (Juelich Supercomputing Centre)
@@ -38,16 +39,25 @@ from easybuild.tools.modules import get_software_root, get_software_libdir
 
 
 class EB_Score_minus_P(ConfigureMake):
-    """Support for building and installing software using the Score-P configuration style."""
+    """
+    Support for building and installing software using the Score-P configuration style (e.g., Cube, OTF2, Scalasca,
+    and Score-P).
+    """
 
     def configure_step(self, *args, **kwargs):
-        """Configure Score-P build, set configure options for compiler, MPI and dependencies."""
+        """Configure the build, set configure options for compiler, MPI and dependencies."""
+        # On non-cross-compile platforms, specify compiler and MPI suite explicitly.  This is much quicker and safer
+        # than autodetection.  In Score-P build-system terms, the following platforms are considered cross-compile
+        # architectures:
+        #
+        #   - Cray XT/XE/XK/XC series
+        #   - Fujitsu FX10, FX100 & K computer
+        #   - IBM Blue Gene series
+        #
+        # Of those, only Cray is supported right now.
         tc_fam = self.toolchain.toolchain_family()
         if tc_fam != toolchain.CRAYPE:
-            # compiler and MPI suite should always be specified -- MUCH quicker and SAFER than autodetect
             # --with-nocross-compiler-suite=(gcc|ibm|intel|pgi|studio)
-            # --with-mpi=(bullxmpi|hp|ibmpoe|intel|intel2|intelpoe|lam|mpibull2|mpich|mpich2|mpich3|openmpi|
-            #             platform|scali|sgimpt|sun)
             comp_opts = {
                 toolchain.DUMMY: 'gcc',  # Assume that dummy toolchain uses a system-provided GCC
                 toolchain.GCC: 'gcc',
@@ -61,17 +71,30 @@ class EB_Score_minus_P(ConfigureMake):
                 raise EasyBuildError("Compiler family %s not supported yet (only: %s)",
                                      comp_fam, ', '.join(comp_opts.keys()))
 
-            mpi_opts = {
-                toolchain.INTELMPI: 'intel2',  # intel: Intel MPI v1.x (ancient); intelpoe: IBM POE MPI for Intel platforms
-                toolchain.OPENMPI: 'openmpi',
-                toolchain.MPICH: 'mpich3',     # In EB terms, MPICH means MPICH 3.x; MPICH 1.x is ancient and unsupported
-                toolchain.MPICH2: 'mpich2',
-                toolchain.MVAPICH2: 'mpich3',  # Though MVAPICH2 is based on MPICH 3.x only since v1.9b, this setting only
-                                               # affects options passed to the MPI (Fortran) compiler wrappers.  And
-                                               # MPICH 3.x compatible options were already supported in MVAPICH2 1.7.
-            }
+            # --with-mpi=(bullxmpi|hp|ibmpoe|intel|intel2|intelpoe|lam|mpibull2|mpich|mpich2|mpich3|openmpi|
+            #             platform|scali|sgimpt|sun)
+            #
+            # Notes:
+            #   - intel:    Intel MPI v1.x (ancient & unsupported)
+            #   - intel2:   Intel MPI v2.x and higher
+            #   - intelpoe: IBM POE MPI for Intel platforms
+            #   - mpich:    MPICH v1.x (ancient & unsupported)
+            #   - mpich2:   MPICH2 v1.x
+            #   - mpich3:   MPICH v3.x & MVAPICH2
+            #               This setting actually only affects options passed to the MPI (Fortran) compiler wrappers.
+            #               And since MPICH v3.x-compatible options were already supported in MVAPICH2 v1.7, it is
+            #               safe to use 'mpich3' for all supported versions although MVAPICH2 is based on MPICH v3.x
+            #               only since v1.9b.
+            #
             # With minimal toolchains, packages using this easyblock may be built with a non-MPI toolchain (e.g., OTF2).
             # In this case, skip passing the '--with-mpi' option.
+            mpi_opts = {
+                toolchain.INTELMPI: 'intel2',
+                toolchain.OPENMPI: 'openmpi',
+                toolchain.MPICH: 'mpich3',     # In EB terms, MPICH means MPICH 3.x
+                toolchain.MPICH2: 'mpich2',
+                toolchain.MVAPICH2: 'mpich3',
+            }
             mpi_fam = self.toolchain.mpi_family()
             if mpi_fam is not None:
                 if mpi_fam in mpi_opts:
@@ -80,7 +103,7 @@ class EB_Score_minus_P(ConfigureMake):
                     raise EasyBuildError("MPI family %s not supported yet (only: %s)",
                                          mpi_fam, ', '.join(mpi_opts.keys()))
 
-        # auto-detection for dependencies mostly works fine, but hard specify paths anyway to have full control
+        # Auto-detection for dependencies mostly works fine, but hard specify paths anyway to have full control
         deps = {
             'binutils': ['--with-libbfd=%s'],
             'libunwind': ['--with-libunwind=%s'],


### PR DESCRIPTION
- [x] Fix bug passing `--with-libbfd` path
- [x] Add `libunwind` suppport
- [x] Add `SIONlib` support
- [x] Add IBM XL compiler support
- [x] Add PGI compiler support (depends on ~~https://github.com/hpcugent/easybuild-framework/pull/1342~~)
- [x] Add MVAPICH2 support
- [x] Add Cray support