### PR TITLE
remove check whether 'easybuild' is being imported from dir that contains easybuild/__init__.py

### DIFF
--- a/easybuild/__init__.py
+++ b/easybuild/__init__.py
@@ -27,14 +27,5 @@
 # You should have received a copy of the GNU General Public License
 # along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
 ##
-import os
 import pkg_resources
-import sys
-
-# check whether EasyBuild is being run from a directory that contains easybuild/__init__.py;
-# that doesn't work (fails with import errors), due to weirdness to Python packaging/setuptools/namespaces
-if __path__[0] == 'easybuild':
-    sys.stderr.write("ERROR: Running EasyBuild from %s does not work (Python packaging weirdness)...\n" % os.getcwd())
-    sys.exit(1)
-
 pkg_resources.declare_namespace(__name__)


### PR DESCRIPTION
This reverts #869, which was needed because of https://github.com/hpcugent/easybuild-framework/pull/1593, but is no longer relevant after the use of fixup_namespace_packages proved not be required (cfr. https://github.com/hpcugent/easybuild-framework/pull/1680).