### PR TITLE
fix bugs w.r.t. --module-only, also test with Lmod as modules tool on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,17 @@
 language: python
-python:
-  - 2.6
-  - 2.7
+python: 2.6
+env:
+  matrix:
+    - ENV_MOD_VERSION=3.2.10
+    - LMOD_VERSION=5.6.3 EASYBUILD_MODULES_TOOL=Lmod
+    - LMOD_VERSION=6.3.1 EASYBUILD_MODULES_TOOL=Lmod EASYBUILD_MODULE_SYNTAX=Lua
+matrix:
+  # mark build as finished as soon as job has failed
+  fast_finish: true
+  include:
+    # also test default configuration with Python 2.7
+    - python: 2.7
+      env: ENV_MOD_VERSION=3.2.10
 addons:
   apt:
     packages:
@@ -13,7 +23,9 @@ install:
     - curl -si https://api.github.com/repos/hpcugent/easybuild-framework/git/refs/heads/${BRANCH} | grep sha
     - easy_install https://github.com/hpcugent/easybuild-framework/archive/${BRANCH}.tar.gz
     # install environment modules tool using 'install_eb_dep.sh' script provided by easybuild-framework
-    - source $(which install_eb_dep.sh) modules-3.2.10 $HOME && source $MOD_INIT
+    - if [ ! -z $ENV_MOD_VERSION ]; then source $(which install_eb_dep.sh) modules-${ENV_MOD_VERSION} $HOME; fi
+    - if [ ! -z $LMOD_VERSION ]; then source $(which install_eb_dep.sh) lua-5.1.4.8 $HOME; fi
+    - if [ ! -z $LMOD_VERSION ]; then source $(which install_eb_dep.sh) Lmod-${LMOD_VERSION} $HOME; fi
 script:
     - export PYTHONPATH=$TRAVIS_BUILD_DIR
     - python -O -m test.easyblocks.suite

--- a/easybuild/easyblocks/d/dolfin.py
+++ b/easybuild/easyblocks/d/dolfin.py
@@ -308,7 +308,9 @@ class EB_DOLFIN(CMakePythonPackage):
         txt = super(EB_DOLFIN, self).make_module_extra()
 
         # Dolfin needs to find Boost
-        txt += self.module_generator.set_environment('BOOST_DIR', self.boost_dir)
+        # check whether boost_dir is defined for compatibility with --module-only
+        if self.boost_dir:
+            txt += self.module_generator.set_environment('BOOST_DIR', self.boost_dir)
 
         envvars = ['I_MPI_CXX', 'I_MPI_CC']
         for envvar in envvars:

--- a/easybuild/easyblocks/n/nwchem.py
+++ b/easybuild/easyblocks/n/nwchem.py
@@ -344,7 +344,11 @@ class EB_NWChem(ConfigureMake):
 
         txt = super(EB_NWChem, self).make_module_extra()
 
-        txt += self.module_generator.set_environment("PYTHONHOME", get_software_root('Python'))
+        # check whether Python module is loaded for compatibility with --module-only
+        python = get_software_root('Python')
+        if python:
+            txt += self.module_generator.set_environment('PYTHONHOME', python)
+
         # '/' at the end is critical for NWCHEM_BASIS_LIBRARY!
         datadir = os.path.join(self.installdir, 'data')
         txt += self.module_generator.set_environment('NWCHEM_BASIS_LIBRARY', os.path.join(datadir, 'libraries/'))

--- a/easybuild/easyblocks/o/openfoam.py
+++ b/easybuild/easyblocks/o/openfoam.py
@@ -354,22 +354,24 @@ class EB_OpenFOAM(EasyBlock):
         txt = super(EB_OpenFOAM, self).make_module_extra()
 
         env_vars = [
-            ("WM_PROJECT_VERSION", self.version),
-            ("FOAM_INST_DIR", self.installdir),
-            ("WM_COMPILER", self.wm_compiler),
-            ("WM_MPLIB", self.wm_mplib),
-            ("FOAM_BASH", os.path.join(self.installdir, self.openfoamdir, "etc", "bashrc")),
-            ("FOAM_CSH", os.path.join(self.installdir, self.openfoamdir, "etc", "cshrc")),
+            ('WM_PROJECT_VERSION', self.version),
+            ('FOAM_INST_DIR', self.installdir),
+            ('WM_COMPILER', self.wm_compiler),
+            ('WM_MPLIB', self.wm_mplib),
+            ('FOAM_BASH', os.path.join(self.installdir, self.openfoamdir, 'etc', 'bashrc')),
+            ('FOAM_CSH', os.path.join(self.installdir, self.openfoamdir, 'etc', 'cshrc')),
         ]
 
         # OpenFOAM >= 3.0.0 can use 64 bit integers
         if 'extend' not in self.name.lower() and LooseVersion(self.version) >= LooseVersion('3.0'):
             if self.toolchain.options['i8']:
-                env_vars += [("WM_LABEL_SIZE", '64')]
+                env_vars += [('WM_LABEL_SIZE', '64')]
             else:
-                env_vars += [("WM_LABEL_SIZE", '32')]
+                env_vars += [('WM_LABEL_SIZE', '32')]
 
         for (env_var, val) in env_vars:
-            txt += self.module_generator.set_environment(env_var, val)
+            # check whether value is defined for compatibility with --module-only
+            if val:
+                txt += self.module_generator.set_environment(env_var, val)
 
         return txt

--- a/easybuild/easyblocks/p/psi.py
+++ b/easybuild/easyblocks/p/psi.py
@@ -184,9 +184,11 @@ class EB_PSI(CMakeMake):
     def make_module_extra(self):
         """Custom variables for PSI module."""
         txt = super(EB_PSI, self).make_module_extra()
-        psi4datadir = glob.glob(os.path.join(self.installdir, 'share', 'psi*'))
-        if len(psi4datadir) != 1:
-            raise EasyBuildError("Could not determine the PSI4 data dir, there are multiple possibilities: ",
-                                 psi4datadir)
-        txt += self.module_generator.set_environment('PSI4DATADIR', psi4datadir[0])
+        share_dir = os.path.join(self.installdir, 'share')
+        if os.path.exists(share_dir):
+            psi4datadir = glob.glob(os.path.join(share_dir, 'psi*'))
+            if len(psi4datadir) == 1:
+                txt += self.module_generator.set_environment('PSI4DATADIR', psi4datadir[0])
+            else:
+                raise EasyBuildError("Failed to find exactly one PSI4 data dir: %s", psi4datadir)
         return txt

--- a/easybuild/easyblocks/w/wps.py
+++ b/easybuild/easyblocks/w/wps.py
@@ -345,28 +345,25 @@ class EB_WPS(EasyBlock):
 
     def sanity_check_step(self):
         """Custom sanity check for WPS."""
-
         custom_paths = {
-                        'files': ["WPS/%s" % x for x in ["geogrid.exe", "metgrid.exe",
-                                                         "ungrib.exe"]],
-                        'dirs': []
-                       }
-
+            'files': ['WPS/%s' % x for x in ['geogrid.exe', 'metgrid.exe', 'ungrib.exe']],
+            'dirs': [],
+        }
         super(EB_WPS, self).sanity_check_step(custom_paths=custom_paths)
 
     def make_module_req_guess(self):
         """Make sure PATH and LD_LIBRARY_PATH are set correctly."""
-
         return {
-                'PATH': [self.name],
-                'LD_LIBRARY_PATH': [self.name],
-                'MANPATH': [],
-               }
+            'PATH': [self.name],
+            'LD_LIBRARY_PATH': [self.name],
+            'MANPATH': [],
+        }
 
     def make_module_extra(self):
         """Add netCDF environment variables to module file."""
         txt = super(EB_WPS, self).make_module_extra()
-        txt += self.module_generator.set_environment('NETCDF', os.getenv('NETCDF'))
-        if os.getenv('NETCDFF', None) is not None:
-            txt += self.module_generator.set_environment('NETCDFF', os.getenv('NETCDFF'))
+        for var in ['NETCDF', 'NETCDFF']:
+            # check whether value is defined for compatibility with --module-only
+            if os.getenv(var) is not None:
+                txt += self.module_generator.set_environment(var, os.getenv(var))
         return txt

--- a/test/easyblocks/module.py
+++ b/test/easyblocks/module.py
@@ -209,7 +209,9 @@ def template_module_only_test(self, easyblock, name='foo', version='1.3.2', extr
             os.chdir(orig_workdir)
 
         modfile = os.path.join(TMPDIR, 'modules', 'all', 'foo', '1.3.2')
-        self.assertTrue(os.path.exists(modfile), "Module file %s was generated" % modfile)
+        luamodfile = '%s.lua' % modfile
+        self.assertTrue(os.path.exists(modfile) or os.path.exists(luamodfile),
+                        "Module file %s or %s was generated" % (modfile, luamodfile))
 
         # cleanup
         app.close_log()

--- a/test/easyblocks/module.py
+++ b/test/easyblocks/module.py
@@ -249,8 +249,6 @@ def suite():
     # add dummy PrgEnv-gnu/1.2.3 module, required for testing CrayToolchain easyblock
     write_file(os.path.join(TMPDIR, 'modules', 'all', 'PrgEnv-gnu', '1.2.3'), "#%Module")
 
-    easyblocks = [e for e in easyblocks if 'cray' in e]
-
     for easyblock in easyblocks:
         # dynamically define new inner functions that can be added as class methods to ModuleOnlyTest
         if os.path.basename(easyblock) == 'systemcompiler.py':


### PR DESCRIPTION
@wpoely86's remark on this in #895 was justified, the modules tool *is* indeed used during the easyblock tests too...

Even better, this is exposing a bug, when using Lmod + Lua syntax for modules (probably just a missing `.lua` extension):

```
======================================================================
FAIL: Test for using --module-only with easyblock /home/travis/build/boegel/easybuild-easyblocks/easybuild/easyblocks/generic/craytoolchain.py
----------------------------------------------------------------------
Traceback (most recent call last):
  File "<string>", line 1, in innertest
  File "/home/travis/build/boegel/easybuild-easyblocks/test/easyblocks/module.py", line 212, in template_module_only_test
    self.assertTrue(os.path.exists(modfile), "Module file %s was generated" % modfile)
AssertionError: Module file /tmp/eb-VbRtsI/eb-oyTAci/modules/all/foo/1.3.2 was generated
----------------------------------------------------------------------
```