### PR TITLE
bug fix: use ConfigureMake's test_step in libxml2 easyblock to run 'make check'

### DIFF
--- a/easybuild/easyblocks/l/libxml2.py
+++ b/easybuild/easyblocks/l/libxml2.py
@@ -74,6 +74,13 @@ class EB_libxml2(ConfigureMake, PythonPackage):
         """
         ConfigureMake.build_step(self)
 
+    def test_step(self):
+        """
+        Test libxml2 build using 'make check'.
+        """
+        self.cfg['runtest'] = 'check'
+        ConfigureMake.test_step(self)
+
     def install_step(self):
         """
         Install libxml2 and install python bindings


### PR DESCRIPTION
without this, installing libxml2 with Python support fails with:

```
...
== testing...
== FAILED: Installation ended unsuccessfully (build directory: /tmp/vsc40023/easybuild_build/libxml2/2.9.3/intel-2016a-Python-2.7.11): build failed (first 300 chars): cmd "make True
" exited with exitcode 2 and output:
make: *** No rule to make target `True'.  Stop.
```