### PR TITLE
extend bzip2 easyblock to also build dynamic libraries.  Required for new R releases

### DIFF
--- a/easybuild/easyblocks/b/bzip2.py
+++ b/easybuild/easyblocks/b/bzip2.py
@@ -64,10 +64,14 @@ class EB_bzip2(ConfigureMake):
             raise EasyBuildError("Copying %s to installation dir %s failed: %s", lib, destdir, err)
 
         # create symlink libbz2.so >> libbz2.so.1.0.6
-        os.chdir(destdir)
-        os.symlink('libbz2.so.%s' % self.cfg['version'], 'libbz2.so') 
-        os.chdir(srcdir)
-        
+        try:
+            os.chdir(destdir)
+            os.symlink('libbz2.so.%s' % self.cfg['version'], 'libbz2.so') 
+            os.chdir(srcdir)
+        except OSError, err:
+            raise EasyBuildError("Creating symlink for libbz2.so failed")
+                    
+
         super(EB_bzip2, self).install_step()
 
     def sanity_check_step(self):

--- a/easybuild/easyblocks/b/bzip2.py
+++ b/easybuild/easyblocks/b/bzip2.py
@@ -45,7 +45,7 @@ class EB_bzip2(ConfigureMake):
         self.cfg.update('prebuildopts', "make -f Makefile-libbz2_so && ")
         self.cfg.update('buildopts', 'CC="%s"' % os.getenv('CC'))
         self.cfg.update('buildopts', "CFLAGS='-Wall -Winline %s -g $(BIGFILES)'" % os.getenv('CFLAGS'))
-   
+
     def install_step(self):
         """Install in non-standard path by passing PREFIX variable to make install."""
 
@@ -65,7 +65,6 @@ class EB_bzip2(ConfigureMake):
 
         # create symlink libbz2.so >> libbz2.so.1.0.6
         os.chdir(destdir)
-        libname = 'libbz2.so.%s' % self.cfg['version']
         os.symlink('libbz2.so.%s' % self.cfg['version'], 'libbz2.so') 
         os.chdir(srcdir)
         

--- a/easybuild/easyblocks/b/bzip2.py
+++ b/easybuild/easyblocks/b/bzip2.py
@@ -63,7 +63,7 @@ class EB_bzip2(ConfigureMake):
         # copy dynamic libraries to install_dir/lib
         try:
             for lib in dynamic_libs_to_copy:
-                os.system('mv %s %s' % (lib, destdir)) # no easy way to copy sysmlinks using python shutil?
+                os.system('cp -P %s %s' % (lib, destdir)) # no easy way to copy sysmlinks using python shutil?
         except OSError, err:
             raise EasyBuildError("Copying %s to installation dir %s failed: %s", lib, destdir, err)
 

--- a/easybuild/easyblocks/b/bzip2.py
+++ b/easybuild/easyblocks/b/bzip2.py
@@ -45,7 +45,7 @@ class EB_bzip2(ConfigureMake):
         self.cfg.update('prebuildopts', "make -f Makefile-libbz2_so && ")
         self.cfg.update('buildopts', 'CC="%s"' % os.getenv('CC'))
         self.cfg.update('buildopts', "CFLAGS='-Wall -Winline %s -g $(BIGFILES)'" % os.getenv('CFLAGS'))
-    
+   
     def install_step(self):
         """Install in non-standard path by passing PREFIX variable to make install."""
 

--- a/easybuild/easyblocks/b/bzip2.py
+++ b/easybuild/easyblocks/b/bzip2.py
@@ -33,6 +33,7 @@ import os
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.run import run_cmd
 
 
 class EB_bzip2(ConfigureMake):
@@ -42,7 +43,6 @@ class EB_bzip2(ConfigureMake):
     def configure_step(self):
         """Set extra configure options (CC, CFLAGS)."""
 
-        self.cfg.update('prebuildopts', "make -f Makefile-libbz2_so && ")
         self.cfg.update('buildopts', 'CC="%s"' % os.getenv('CC'))
         self.cfg.update('buildopts', "CFLAGS='-Wall -Winline %s -g $(BIGFILES)'" % os.getenv('CFLAGS'))
 
@@ -50,6 +50,10 @@ class EB_bzip2(ConfigureMake):
         """Install in non-standard path by passing PREFIX variable to make install."""
 
         self.cfg.update('installopts', "PREFIX=%s" % self.installdir)
+        
+        # build dynamic library
+        cmd = 'make -f Makefile-libbz2_so'
+        run_cmd(cmd, log_all=True, simple=True)
         
         srcdir = self.cfg['start_dir']
         destdir = os.path.join(self.installdir, 'lib/')
@@ -70,7 +74,6 @@ class EB_bzip2(ConfigureMake):
             os.chdir(srcdir)
         except OSError, err:
             raise EasyBuildError("Creating symlink for libbz2.so failed")
-                    
 
         super(EB_bzip2, self).install_step()
 


### PR DESCRIPTION
Current bzip2 block builds only static library `libbz2.a`

This block also builds bzip2 dynamic libraries:

```
libbz2.so -> libbz2.so.1.0.6
libbz2.so.1.0 -> libbz2.so.1.0.6
libbz2.so.1.0.6
```

Latest `R-3.3.0` released few days ago requires `libbz2.so` to build so you it's not possible to build latest `R-3.3.0` if you are using current bzip2 easyblock in easybuild (unless you provide `libbz2.so` from OS packages)

 
