### PR TITLE
also filter out -ldl from $LIBBLAS & co in Intel MKL easyblock

### DIFF
--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -117,7 +117,7 @@ class EB_numpy(FortranPythonPackage):
             def get_libs_for_mkl(varname):
                 """Get list of libraries as required for MKL patch file."""
                 libs = self.toolchain.variables['LIB%s' % varname].copy()
-                libs.try_remove(['pthread'])
+                libs.try_remove(['pthread', 'dl'])
                 tweaks = {
                     'prefix': '',
                     'prefix_begin_end': '-Wl:',


### PR DESCRIPTION
with https://github.com/hpcugent/easybuild-framework/pull/1764 included, this is only needed for compiling numpy with PGI