### PR TITLE
added support for java6

### DIFF
--- a/easybuild/easyblocks/j/java.py
+++ b/easybuild/easyblocks/j/java.py
@@ -27,13 +27,32 @@ EasyBlock for installing Java, implemented as an easyblock
 
 @author: Jens Timmerman (Ghent University)
 """
+from distutils.version import LooseVersion
 from easybuild.easyblocks.generic.packedbinary import PackedBinary
+from easybuild.tools.run import run_cmd
 
 
 class EB_Java(PackedBinary):
+#class PackedBinary(Binary, EasyBlock):
     """Support for installing Java as a packed binary file (.tar.gz)
     Use the PackedBinary easyblock and set some extra paths.
     """
+    
+    def extract_step(self):
+        """Unpack the source"""
+        #print LooseVersion(self.version)
+        #print self.src
+        print self.builddir
+        if LooseVersion(self.version) < LooseVersion('1.7'):
+            # uncompress java6 to build dir
+            cmd = 'cd %s; yes | bash %s' % (self.builddir, self.src[0]['path'])
+            #print cmd
+            run_cmd(cmd, log_all=True, simple=True)
+            cmd2 = 'cp -r %s/* %s' % (self.builddir, self.installdir)
+            run_cmd(cmd2, log_all=True, simple=True)
+        else:
+            PackedBinary.extract_step(self)
+
     def make_module_extra(self):
         """
         Set JAVA_HOME to install dir


### PR DESCRIPTION
I know this is not ready to merge. @boegel please review? :)

This is an easyconfig to test
https://gist.github.com/10a77ea9b266f3020b40bbfb8c582f51

To download java jdk6: 
`wget --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/6u24-b07/jdk-6u24-linux-x64.bin`