### PR TITLE
Added support for the double-precision for gromacs

### DIFF
--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -182,6 +182,11 @@ class EB_GROMACS(CMakeMake):
         if self.toolchain.options.get('usempi', None):
             suff = '_mpi'
 
+        # Add the _d suffix to the suffix, in case of the double precission
+        if '-DGMX_DOUBLE=on' in self.cfg['configopts']:
+            suff = suff+'_d'
+
+
         # in GROMACS v5.1, only 'gmx' binary is there
         # (only) in GROMACS v5.0, other binaries are symlinks to 'gmx'
         binaries = []

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -184,7 +184,9 @@ class EB_GROMACS(CMakeMake):
 
         # Add the _d suffix to the suffix, in case of the double precission
         if '-DGMX_DOUBLE=on' in self.cfg['configopts']:
-            suff = suff+'_d'
+            suff = suff + '_d'
+        elif '-DGMX_DOUBLE=ON' in self.cfg['configopts']:
+            suff = suff + '_d'
 
 
         # in GROMACS v5.1, only 'gmx' binary is there

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -188,7 +188,6 @@ class EB_GROMACS(CMakeMake):
         elif '-DGMX_DOUBLE=ON' in self.cfg['configopts']:
             suff = suff + '_d'
 
-
         # in GROMACS v5.1, only 'gmx' binary is there
         # (only) in GROMACS v5.0, other binaries are symlinks to 'gmx'
         binaries = []


### PR DESCRIPTION
Hi,

This is my pull request related to the support for gromacs with double precision as discussed on the mailing list in the `easyblock` of gromacs.

In the `easyconfig` of gromacs to the following line needs to be added:

```
configopts='-DGMX_DOUBLE=on'
```

With this modification the suffix `_d` will be added, since that will be added when compiled with double precision.

Regards,

Pieter
