### PR TITLE
create 'release' symlink in MRtrix install dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ LICENSE_HEADER
 build/
 dist/
 *egg-info/
+*.swp

--- a/easybuild/easyblocks/m/mrtrix.py
+++ b/easybuild/easyblocks/m/mrtrix.py
@@ -84,6 +84,8 @@ class EB_MRtrix(EasyBlock):
                 os.rmdir(self.installdir)
                 shutil.copytree(release_dir, self.installdir)
                 shutil.copytree(scripts_dir, os.path.join(self.installdir, 'scripts'))
+                # some scripts expect 'release/bin' to be there, so we put a symlink in place
+                os.symlink(self.installdir, os.path.join(self.installdir, 'release'))
             except OSError as err:
                 raise EasyBuildError("Failed to copy %s & %s to %s: %s", release_dir, scripts_dir, self.installdir, err)
 


### PR DESCRIPTION
fix for these issues:

```

Traceback (most recent call last):
  File "/apps/gent/SL6/sandybridge/software/MRtrix/0.3.14-intel-2016a-Python-2.7.11/scripts/5ttgen", line 45, in <module>
    runCommand('mrconvert ' + lib.app.args.input + ' ' + os.path.join(lib.app.tempDir, 'input.mif'))
  File "/vscmnt/gent_vulpix_apps/_apps_gent/SL6/sandybridge/software/MRtrix/0.3.14-intel-2016a-Python-2.7.11/scripts/lib/runCommand.py", line 12, in runCommand
    mrtrix_bin_list = os.listdir(mrtrix_bin_path)
OSError: [Errno 2] No such file or directory: '/vscmnt/gent_vulpix_apps/_apps_gent/SL6/sandybridge/software/MRtrix/0.3.14-intel-2016a-Python-2.7.11/scripts/../release/bin'
```
 
```
Traceback (most recent call last):
  File "/apps/gent/SL6/sandybridge/software/MRtrix/0.3.14-intel-2016a-Python-2.7.11/scripts/dwi2response", line 66, in <module>
    algorithm.getInputFiles()
  File "/vscmnt/gent_vulpix_apps/_apps_gent/SL6/sandybridge/software/MRtrix/0.3.14-intel-2016a-Python-2.7.11/scripts/src/dwi2response/msmt_5tt.py", line 31, in getInputFiles
    runCommand('mrconvert ' + lib.app.args.in_5tt + ' ' + os.path.join(lib.app.tempDir, '5tt.mif'))
  File "/vscmnt/gent_vulpix_apps/_apps_gent/SL6/sandybridge/software/MRtrix/0.3.14-intel-2016a-Python-2.7.11/scripts/lib/runCommand.py", line 12, in runCommand
    mrtrix_bin_list = os.listdir(mrtrix_bin_path)
OSError: [Errno 2] No such file or directory: '/vscmnt/gent_vulpix_apps/_apps_gent/SL6/sandybridge/software/MRtrix/0.3.14-intel-2016a-Python-2.7.11/scripts/../release/bin'
```