### PR TITLE
fix make_installdir in Inspector & VTune easyblocks

### DIFF
--- a/easybuild/easyblocks/i/inspector.py
+++ b/easybuild/easyblocks/i/inspector.py
@@ -49,7 +49,7 @@ class EB_Inspector(IntelBase):
 
     def make_installdir(self):
         """Do not create installation directory, install script handles that already."""
-        pass
+        super(EB_Inspector, self).make_installdir(dontcreate=True)
 
     def install_step(self):
         """

--- a/easybuild/easyblocks/v/vtune.py
+++ b/easybuild/easyblocks/v/vtune.py
@@ -49,7 +49,7 @@ class EB_VTune(IntelBase):
 
     def make_installdir(self):
         """Do not create installation directory, install script handles that already."""
-        pass
+        super(EB_VTune, self).make_installdir(dontcreate=True)
 
     def install_step(self):
         """


### PR DESCRIPTION
Fix for problem reported by @jhein32: making `make_installdir` a no-op has the unwanted side-effect of not cleaning up the installation directory  when doing a forced reinstallation, which leads to:

```
 == 2016-06-08 11:40:31,549 run.py:99 DEBUG run_cmd: running cmd ./install.sh  -s /local/easybuild/build/VTune/2016_update3/dummy-dummy/vtune_amplifier_xe_2016_update3/silent.cfg (in /local/easybuild/build
/VTune/2016_update3/dummy-dummy/vtune_amplifier_xe_2016_update3)
== 2016-06-08 11:40:31,549 run.py:107 DEBUG run_cmd: Command output will be logged to /tmp/eb-c_vKEE/easybuild-run_cmd-N5ooC7.log
== 2016-06-08 11:40:42,289 run.py:392 DEBUG cmd "./install.sh  -s /local/easybuild/build/VTune/2016_update3/dummy-dummy/vtune_amplifier_xe_2016_update3/silent.cfg" exited with exitcode 2 and output:
WARNING: Destination directory already exists. 
Installing to this directory could overwrite existing files and folders within
this directory.
--------------------------------------------------------------------------------
```

This change makes sure that the install directory is not created, but it does get cleaned up when it needs to be, e.g. during a forced re-installation.