### PR TITLE
update GROMACS easyblock for Cray, double precision & old GROMACS versions

### DIFF
--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -56,6 +56,7 @@ class EB_GROMACS(CMakeMake):
     @staticmethod
     def extra_options():
         extra_vars = {
+            'double_precision': [False, "Build with double precision enabled (-DGMX_DOUBLE=ON)", CUSTOM],
             'mpisuffix': ['_mpi', "Suffix to append to MPI-enabled executables", CUSTOM],
             'mpiexec': ['mpirun', "MPI executable to use when running tests", CUSTOM],
             'mpiexec_numproc_flag': ['-np', "Flag to introduce the number of MPI tasks when running tests", CUSTOM],
@@ -112,6 +113,9 @@ class EB_GROMACS(CMakeMake):
                 self.cfg.update('configopts', "-DGMX_PREFER_STATIC_LIBS=OFF")
             else:
                 self.cfg.update('configopts', "-DGMX_PREFER_STATIC_LIBS=ON")
+
+            if self.cfg['double_precision']:
+                self.cfg.update('configopts', "-DGMX_DOUBLE=ON")
 
             # always specify to use external BLAS/LAPACK
             self.cfg.update('configopts', "-DGMX_EXTERNAL_BLAS=ON -DGMX_EXTERNAL_LAPACK=ON")
@@ -290,9 +294,7 @@ class EB_GROMACS(CMakeMake):
             suff = '_mpi'
 
         # Add the _d suffix to the suffix, in case of the double precission
-        if '-DGMX_DOUBLE=on' in self.cfg['configopts']:
-            suff = suff + '_d'
-        elif '-DGMX_DOUBLE=ON' in self.cfg['configopts']:
+        if re.search('DGMX_DOUBLE=(ON|YES|TRUE|Y|[1-9])', self.cfg['configopts'], re.I):
             suff = suff + '_d'
 
         dirs = [os.path.join('include', 'gromacs')]

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -277,7 +277,7 @@ class EB_GROMACS(CMakeMake):
                 # rebuild/test/install with MPI options
                 super(EB_GROMACS, self).configure_step()
                 super(EB_GROMACS, self).build_step()
-                super(EB_GROMACS, self).test_step()
+                self.test_step()
                 super(EB_GROMACS, self).install_step()
 
                 self.log.info("A full regression test suite is available from the GROMACS web site")

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -210,6 +210,8 @@ class EB_GROMACS(CMakeMake):
         Custom install step for GROMACS; figure out where libraries were installed to.
         Also, install the MPI version of the executable in a separate step.
         """
+        # run 'make install' in parallel since it involves more compilation
+        self.cfg.update('installopts', "-j %s" % self.cfg['parallel'])
         super(EB_GROMACS, self).install_step()
 
         # the GROMACS libraries get installed in different locations (deeper subdirectory), depending on the platform;

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -164,8 +164,9 @@ class EB_GROMACS(CMakeMake):
                     else:
                         # -DGMX_BLAS_USER & -DGMX_LAPACK_USER require full path to library
                         libs = os.getenv('%s_STATIC_LIBS' % libname).split(',')
-                        self.cfg.update('configopts', '-DGMX_%s_USER="%s"' % (libname, os.path.join(libdir, libs[0])))
-                        # if libgfortran.a is listed too, make sure it gets linked in too to avoiding linking issues
+                        libpaths = [os.path.join(libdir, lib) for lib in libs if lib != 'libgfortran.a']
+                        self.cfg.update('configopts', '-DGMX_%s_USER="%s"' % (libname, ';'.join(libpaths)))
+                        # if libgfortran.a is listed, make sure it gets linked in too to avoiding linking issues
                         if 'libgfortran.a' in libs:
                             os.environ['LDFLAGS'] = "%s -lgfortran -lm" % os.getenv('LDFLAGS')
 

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -162,11 +162,12 @@ class EB_GROMACS(CMakeMake):
                         else:
                             raise EasyBuildError("Failed to find libsci library to link with for %s", libname)
                     else:
+                        # -DGMX_BLAS_USER & -DGMX_LAPACK_USER require full path to library
                         libs = os.getenv('%s_STATIC_LIBS' % libname).split(',')
                         self.cfg.update('configopts', '-DGMX_%s_USER="%s"' % (libname, os.path.join(libdir, libs[0])))
+                        # if libgfortran.a is listed too, make sure it gets linked in too to avoiding linking issues
                         if 'libgfortran.a' in libs:
-                            for var in ['CFLAGS', 'CXXFLAGS', 'FFLAGS']:
-                                os.environ[var] = "%s -lgfortran" % os.getenv(var)
+                            os.environ['LDFLAGS'] = "%s -lgfortran -lm" % os.getenv('LDFLAGS')
 
             # no more GSL support in GROMACS 5.x, see http://redmine.gromacs.org/issues/1472
             if LooseVersion(self.version) < LooseVersion('5.0'):

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -80,7 +80,7 @@ class EB_GROMACS(CMakeMake):
 
             # Use external BLAS and LAPACK
             self.cfg.update('configopts', "--with-external-blas --with-external-lapack")
-            os.environ['LIBS'] = "%s %s" % (os.environ['LIBLAPACK'], os.environ['LIBS'])
+            env.setvar('LIBS', "%s %s" % (os.environ['LIBLAPACK'], os.environ['LIBS']))
 
             # Don't use the X window system
             self.cfg.update('configopts', "--without-x")
@@ -168,7 +168,7 @@ class EB_GROMACS(CMakeMake):
                         self.cfg.update('configopts', '-DGMX_%s_USER="%s"' % (libname, ';'.join(libpaths)))
                         # if libgfortran.a is listed, make sure it gets linked in too to avoiding linking issues
                         if 'libgfortran.a' in libs:
-                            os.environ['LDFLAGS'] = "%s -lgfortran -lm" % os.getenv('LDFLAGS')
+                            env.setvar('LDFLAGS', "%s -lgfortran -lm" % os.environ.get('LDFLAGS', ''))
 
             # no more GSL support in GROMACS 5.x, see http://redmine.gromacs.org/issues/1472
             if LooseVersion(self.version) < LooseVersion('5.0'):

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -152,15 +152,14 @@ class EB_GROMACS(CMakeMake):
                 mkl_libs = [os.path.join(os.getenv('LAPACK_LIB_DIR'), lib) for lib in ['libmkl_lapack.a']]
                 self.cfg.update('configopts', '-DMKL_LIBRARIES="%s" ' % ';'.join(mkl_libs))
             else:
+                shlib_ext = get_shared_lib_ext()
                 for libname in ['BLAS', 'LAPACK']:
                     lib_dir = os.getenv('%s_LIB_DIR' % libname)
                     libs = os.getenv('LIB%s' % libname)
                     if self.toolchain.toolchain_family() == toolchain.CRAYPE:
                         self.cfg.update('configopts', '-DGMX_%s_USER="%s/libsci_gnu_mpi_mp.a"' % (libname, lib_dir))
                     else:
-                        # FIXME
-                        libfile = "lib" + libs.split('-l')[1].rstrip() + ".so"
-                        libstr = os.path.join(lib_dir, libfile)
+                        libstr = os.path.join(lib_dir, 'lib' + libs.split('-l')[1].rstrip() + shlib_ext)
                         self.cfg.update('configopts', '-DGMX_%s_USER="%s"' % (libname, libstr))
 
             # no more GSL support in GROMACS 5.x, see http://redmine.gromacs.org/issues/1472

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -154,9 +154,9 @@ class EB_GROMACS(CMakeMake):
             else:
                 shlib_ext = get_shared_lib_ext()
                 for libname in ['BLAS', 'LAPACK']:
-                    lib_dir = os.getenv('%s_LIB_DIR' % libname)
+                    libdir = os.getenv('%s_LIB_DIR' % libname)
                     if self.toolchain.toolchain_family() == toolchain.CRAYPE:
-                        self.cfg.update('configopts', '-DGMX_%s_USER="%s/libsci_gnu_mpi_mp.a"' % (libname, lib_dir))
+                        self.cfg.update('configopts', '-DGMX_%s_USER="%s/libsci_gnu_mpi_mp.a"' % (libname, libdir))
                     else:
                         libs = os.getenv('LIB%s' % libname)
                         self.cfg.update('configopts', '-DGMX_%s_USER="-L%s %s"' % (libname, libdir, libs))

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -277,7 +277,7 @@ class EB_GROMACS(CMakeMake):
                 # rebuild/test/install with MPI options
                 super(EB_GROMACS, self).configure_step()
                 super(EB_GROMACS, self).build_step()
-                self.test_step()
+                super(EB_GROMACS, self).test_step()
                 super(EB_GROMACS, self).install_step()
 
                 self.log.info("A full regression test suite is available from the GROMACS web site")

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -272,9 +272,10 @@ class EB_GROMACS(CMakeMake):
                 # clean up obj dir before reconfiguring
                 shutil.rmtree(os.path.join(self.builddir, 'easybuild_obj'))
 
-                # rebuild/install with MPI options
+                # rebuild/test/install with MPI options
                 super(EB_GROMACS, self).configure_step()
                 super(EB_GROMACS, self).build_step()
+                super(EB_GROMACS, self).test_step()
                 super(EB_GROMACS, self).install_step()
 
                 self.log.info("A full regression test suite is available from the GROMACS web site")

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -240,11 +240,8 @@ class EB_GROMACS(CMakeMake):
                 self.cfg.update('configopts', "--enable-mpi --program-suffix={0}".format(self.cfg['mpisuffix']))
                 ConfigureMake.configure_step(self)
 
-                #self.cfg.update('buildopts', 'mdrun')  # FIXME
                 super(EB_GROMACS, self).build_step()
 
-                #cmd = "%s make install-mdrun %s" % (self.cfg['preinstallopts'], self.cfg['installopts'])  # FIXME
-                #(out, _) = run_cmd(cmd, log_all=True, simple=False)
                 super(EB_GROMACS, self).install_step()
 
             else:
@@ -261,7 +258,6 @@ class EB_GROMACS(CMakeMake):
                 self.cfg.update('configopts', "-DGMX_MPI=ON -DGMX_THREAD_MPI=OFF -DMPIEXEC=%s" % self.cfg['mpiexec'])
                 self.cfg.update('configopts', "-DMPIEXEC_NUMPROC_FLAG=%s" % self.cfg['mpiexec_numproc_flag'])
                 self.cfg.update('configopts', "-DNUMPROC=%s" % self.cfg['mpi_numprocs'])
-                #self.cfg.update('configopts', "-DGMX_BUILD_MDRUN_ONLY=ON")  # FIXME
 
                 self.log.info("Using %s as MPI executable when testing, with numprocs flag '%s' and %s tasks",
                               self.cfg['mpiexec'], self.cfg['mpiexec_numproc_flag'], self.cfg['mpi_numprocs'])

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -178,6 +178,13 @@ class EB_GROMACS(CMakeMake):
                 else:
                     self.cfg.update('configopts', "-DGMX_GSL=OFF")
 
+            # include flags for linking to zlib/XZ in $LDFLAGS if they're listed as a dep;
+            # this is important for the tests, to correctly link against libxml2
+            if get_software_root('zlib'):
+                env.setvar('LDFLAGS', "%s -lz" % os.environ.get('LDFLAGS', ''))
+            if get_software_root('XZ'):
+                env.setvar('LDFLAGS', "%s -llzma" % os.environ.get('LDFLAGS', ''))
+
             # complete configuration with configure_method of parent
             self.cfg['separate_build_dir'] = True
             out = super(EB_GROMACS, self).configure_step()

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -264,13 +264,16 @@ class EB_GROMACS(CMakeMake):
                     self.log.warning("Number of test MPI tasks (%s) is greater than value for 'parallel': %s",
                                      self.cfg['mpi_numprocs'], self.cfg['parallel'])
 
+                self.cfg.update('configopts', "-DGMX_MPI=ON -DGMX_THREAD_MPI=OFF")
+
                 mpiexec = which(self.cfg['mpiexec'])
-                if mpiexec is None:
+                if mpiexec:
+                    self.cfg.update('configopts', "-DMPIEXEC=%s" % mpiexec)
+                    self.cfg.update('configopts', "-DMPIEXEC_NUMPROC_FLAG=%s" % self.cfg['mpiexec_numproc_flag'])
+                    self.cfg.update('configopts', "-DNUMPROC=%s" % self.cfg['mpi_numprocs'])
+                elif self.cfg['runtest']:
                     raise EasyBuildError("'%s' not found in $PATH", self.cfg['mpiexec'])
 
-                self.cfg.update('configopts', "-DGMX_MPI=ON -DGMX_THREAD_MPI=OFF -DMPIEXEC=%s" % mpiexec)
-                self.cfg.update('configopts', "-DMPIEXEC_NUMPROC_FLAG=%s" % self.cfg['mpiexec_numproc_flag'])
-                self.cfg.update('configopts', "-DNUMPROC=%s" % self.cfg['mpi_numprocs'])
 
                 self.log.info("Using %s as MPI executable when testing, with numprocs flag '%s' and %s tasks",
                               self.cfg['mpiexec'], self.cfg['mpiexec_numproc_flag'], self.cfg['mpi_numprocs'])

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -155,12 +155,11 @@ class EB_GROMACS(CMakeMake):
                 shlib_ext = get_shared_lib_ext()
                 for libname in ['BLAS', 'LAPACK']:
                     lib_dir = os.getenv('%s_LIB_DIR' % libname)
-                    libs = os.getenv('LIB%s' % libname)
                     if self.toolchain.toolchain_family() == toolchain.CRAYPE:
                         self.cfg.update('configopts', '-DGMX_%s_USER="%s/libsci_gnu_mpi_mp.a"' % (libname, lib_dir))
                     else:
-                        libstr = os.path.join(lib_dir, 'lib' + libs.split('-l')[1].rstrip() + shlib_ext)
-                        self.cfg.update('configopts', '-DGMX_%s_USER="%s"' % (libname, libstr))
+                        libs = os.getenv('LIB%s' % libname)
+                        self.cfg.update('configopts', '-DGMX_%s_USER="-L%s %s"' % (libname, libdir, libs))
 
             # no more GSL support in GROMACS 5.x, see http://redmine.gromacs.org/issues/1472
             if LooseVersion(self.version) < LooseVersion('5.0'):

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -45,7 +45,7 @@ from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import download_file, extract_file, which
-from easybuild.tools.modules import get_software_root
+from easybuild.tools.modules import get_software_libdir, get_software_root
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_platform_name , get_shared_lib_ext
 
@@ -180,10 +180,12 @@ class EB_GROMACS(CMakeMake):
 
             # include flags for linking to zlib/XZ in $LDFLAGS if they're listed as a dep;
             # this is important for the tests, to correctly link against libxml2
-            if get_software_root('zlib'):
-                env.setvar('LDFLAGS', "%s -lz" % os.environ.get('LDFLAGS', ''))
-            if get_software_root('XZ'):
-                env.setvar('LDFLAGS', "%s -llzma" % os.environ.get('LDFLAGS', ''))
+            for dep, link_flag in [('XZ', '-llzma'), ('zlib', '-lz')]:
+                root = get_software_root(dep)
+                if root:
+                    libdir = get_software_libdir(dep)
+                    ldflags = os.environ.get('LDFLAGS', '')
+                    env.setvar('LDFLAGS', "%s -L%s %s" % (ldflags, os.path.join(root, libdir), link_flag))
 
             # complete configuration with configure_method of parent
             self.cfg['separate_build_dir'] = True

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -44,7 +44,7 @@ from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import download_file, extract_file
+from easybuild.tools.filetools import download_file, extract_file, which
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_platform_name , get_shared_lib_ext
@@ -264,7 +264,11 @@ class EB_GROMACS(CMakeMake):
                     self.log.warning("Number of test MPI tasks (%s) is greater than value for 'parallel': %s",
                                      self.cfg['mpi_numprocs'], self.cfg['parallel'])
 
-                self.cfg.update('configopts', "-DGMX_MPI=ON -DGMX_THREAD_MPI=OFF -DMPIEXEC=%s" % self.cfg['mpiexec'])
+                mpiexec = which(self.cfg['mpiexec'])
+                if mpiexec is None:
+                    raise EasyBuildError("'%s' not found in $PATH", self.cfg['mpiexec'])
+
+                self.cfg.update('configopts', "-DGMX_MPI=ON -DGMX_THREAD_MPI=OFF -DMPIEXEC=%s" % mpiexec)
                 self.cfg.update('configopts', "-DMPIEXEC_NUMPROC_FLAG=%s" % self.cfg['mpiexec_numproc_flag'])
                 self.cfg.update('configopts', "-DNUMPROC=%s" % self.cfg['mpi_numprocs'])
 

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -297,7 +297,7 @@ class EB_GROMACS(CMakeMake):
             bins.append('gmx')
             libnames.append('gromacs')
             if LooseVersion(self.version) < LooseVersion('5.1') and self.toolchain.options.get('usempi', None):
-                bins.append('mdrun' + suff)
+                bins.append('mdrun')
         else:
             libnames.extend(['gmxana', 'gmx', 'md'])
             # note: gmxpreprocess may also already be there for earlier versions


### PR DESCRIPTION
This is a combination of #569 (by @valtandor), #946 (@paderijk) and ~~#951~~ (@gppezzi), with some ~~sprinkles~~cleanup/fixes on top...

WIP because:

* [x] fix sanity check, now suffixes get included twice sometimes resulting in `libgromacs_mpi_mpi.a`
* [x] need to find better way of enabling double precision & using correct suffix in sanity check
  * cfr. discussion in #946
* [x] double-check what the intention was of the 'mdrun-only' configure options that @valtandor added in #569 ~~(see `FIXME`s)~~
   * cfr. https://github.com/hpcugent/easybuild-easyblocks/pull/569/files#r68004579
* [x] verify that none of the existing easyconfigs are broken (only tested a couple so far)
* [x] test with:
  * [x] https://github.com/hpcugent/easybuild-easyconfigs/pull/1446
  * [x] https://github.com/hpcugent/easybuild-easyconfigs/pull/2348
  * [x] https://github.com/hpcugent/easybuild-easyconfigs/pull/3051
  * [x] https://github.com/hpcugent/easybuild-easyconfigs/pull/3138
  * [x] https://github.com/hpcugent/easybuild-easyconfigs/pull/3125
  * [x] ~~https://github.com/hpcugent/easybuild-easyconfigs/pull/3195~~
  * [x] https://github.com/hpcugent/easybuild-easyconfigs/pull/3249