### PR TITLE
prepend tmp install path to $PYTHONPATH in numpy test step

### DIFF
--- a/easybuild/easyblocks/generic/pythonpackage.py
+++ b/easybuild/easyblocks/generic/pythonpackage.py
@@ -293,7 +293,7 @@ class PythonPackage(ExtensionEasyBlock):
         # set Python lib directories
         self.set_pylibdirs()
 
-    def compose_install_command(self, prefix, extrapath=None):
+    def compose_install_command(self, prefix, extrapath=None, installopts=None):
         """Compose full install command."""
 
         # mainly for debugging
@@ -327,10 +327,13 @@ class PythonPackage(ExtensionEasyBlock):
             # specify path to 1st source file
             loc = self.src[0]['path']
 
+        if installopts is None:
+            installopts = self.cfg['installopts']
+
         cmd.extend([
             self.cfg['preinstallopts'],
             self.install_cmd % {
-                'installopts': self.cfg['installopts'],
+                'installopts': installopts,
                 'loc': loc,
                 'prefix': prefix,
                 'python': self.python_cmd,

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -308,7 +308,12 @@ class EB_numpy(FortranPythonPackage):
         super(EB_numpy, self).install_step()
 
         builddir = os.path.join(self.builddir, "numpy")
-        if os.path.isdir(builddir):
-            rmtree2(builddir)
-        else:
-            self.log.debug("build dir %s already clean" % builddir)
+        try:
+            if os.path.isdir(builddir):
+                os.chdir(self.builddir)
+                rmtree2(builddir)
+            else:
+                self.log.debug("build dir %s already clean" % builddir)
+
+        except OSError as err:
+            raise EasyBuildError("Failed to clean up numpy build dir %s: %s", builddir, err)

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -277,7 +277,7 @@ class EB_numpy(FortranPythonPackage):
         """Custom sanity check for numpy."""
 
         custom_paths = {
-            'files': [os.path.join(self.pylibdir, 'numpy', '__init__.py')],
+            'files': [self.pylibdir],
             'dirs': [],
         }
         custom_commands = [

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -219,7 +219,7 @@ class EB_numpy(FortranPythonPackage):
         tmpdir = tempfile.mkdtemp()
         abs_pylibdirs = [os.path.join(tmpdir, pylibdir) for pylibdir in self.all_pylibdirs]
         pythonpath = "export PYTHONPATH=%s &&" % os.pathsep.join(abs_pylibdirs + ['$PYTHONPATH'])
-        cmd = self.compose_install_command(tmpdir, extrapath=pythonpath)
+        cmd = self.compose_install_command(tmpdir, extrapath=pythonpath, installopts=self.installopts)
         run_cmd(cmd, log_all=True, simple=True, verbose=False)
 
         try:

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -40,7 +40,7 @@ import easybuild.tools.toolchain as toolchain
 from easybuild.easyblocks.generic.fortranpythonpackage import FortranPythonPackage
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import rmtree2
+from easybuild.tools.filetools import mkdir, rmtree2
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
 from distutils.version import LooseVersion
@@ -218,6 +218,8 @@ class EB_numpy(FortranPythonPackage):
         # temporarily install numpy, it doesn't alow to be used straight from the source dir
         tmpdir = tempfile.mkdtemp()
         abs_pylibdirs = [os.path.join(tmpdir, pylibdir) for pylibdir in self.all_pylibdirs]
+        for pylibdir in abs_pylibdirs:
+            mkdir(pylibdir, parents=True)
         pythonpath = "export PYTHONPATH=%s &&" % os.pathsep.join(abs_pylibdirs + ['$PYTHONPATH'])
         cmd = self.compose_install_command(tmpdir, extrapath=pythonpath, installopts=self.installopts)
         run_cmd(cmd, log_all=True, simple=True, verbose=False)

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -217,7 +217,9 @@ class EB_numpy(FortranPythonPackage):
 
         # temporarily install numpy, it doesn't alow to be used straight from the source dir
         tmpdir = tempfile.mkdtemp()
-        cmd = "%s setup.py install --prefix=%s %s" % (self.python_cmd, tmpdir, self.installopts)
+        abs_pylibdirs = [os.path.join(tmpdir, pylibdir) for pylibdir in self.all_pylibdirs]
+        pythonpath = "export PYTHONPATH=%s &&" % os.pathsep.join(abs_pylibdirs + ['$PYTHONPATH'])
+        cmd = self.compose_install_command(tmpdir, extrapath=pythonpath)
         run_cmd(cmd, log_all=True, simple=True, verbose=False)
 
         try:
@@ -229,7 +231,7 @@ class EB_numpy(FortranPythonPackage):
         # evaluate performance of numpy.dot (3 runs, 3 loops each)
         size = 1000
         cmd = ' '.join([
-            'export PYTHONPATH=%s:$PYTHONPATH &&' % os.path.join(tmpdir, self.pylibdir),
+            pythonpath,
             '%s -m timeit -n 3 -r 3' % self.python_cmd,
             '-s "import numpy; x = numpy.random.random((%(size)d, %(size)d))"' % {'size': size},
             '"numpy.dot(x, x.T)"',

--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -277,8 +277,8 @@ class EB_numpy(FortranPythonPackage):
         """Custom sanity check for numpy."""
 
         custom_paths = {
-            'files': [self.pylibdir],
-            'dirs': [],
+            'files': [],
+            'dirs': [self.pylibdir],
         }
         custom_commands = [
             ('python', '-c "import numpy"'),


### PR DESCRIPTION
The `$PYTHONPATH` should have included the temporary install location all along, but this was not a problem up until now because numpy was still using `distutils`; with numpy 1.11, they switched to using `setuptools`, which means you run into this problem during the numpy test step:

```
running install
Checking .pth file support in <numpy_install_prefix>
/user/scratch/gent/vsc400/vsc40023/easybuild_REGTEST/SL6/sandybridge/software/Python/2.7.11-intel-2016a/bin/python -E -c pass
TEST FAILED: /local/2297564[2861].master15.delcatty.gent.vsc/eb-cVBudI/tmpmFHiMz/lib/python2.7/site-packages does NOT support .pth files
error: bad install directory or PYTHONPATH

You are attempting to install a package to a directory that is not
on PYTHONPATH and which Python does not read ".pth" files from.
...
```

This should fix the issue reported by @damianam in https://github.com/hpcugent/easybuild-easyconfigs/pull/2861