### PR TITLE
Boost root env variable

### DIFF
--- a/easybuild/easyblocks/b/boost.py
+++ b/easybuild/easyblocks/b/boost.py
@@ -215,3 +215,10 @@ class EB_Boost(EasyBlock):
             custom_paths["files"].append('lib/libboost_python.%s' % shlib_ext)
 
         super(EB_Boost, self).sanity_check_step(custom_paths=custom_paths)
+
+    def make_module_extra(self):
+        """Set up a BOOST_ROOT environment variable to e.g. ease Boost handling by cmake"""
+        txt = super(EB_Boost, self).make_module-extra()
+        txt = self.module_generator.set_environment('BOOST_ROOT', self.installdir)
+        return txt
+    

--- a/easybuild/easyblocks/b/boost.py
+++ b/easybuild/easyblocks/b/boost.py
@@ -218,7 +218,7 @@ class EB_Boost(EasyBlock):
 
     def make_module_extra(self):
         """Set up a BOOST_ROOT environment variable to e.g. ease Boost handling by cmake"""
-        txt = super(EB_Boost, self).make_module-extra()
-        txt = self.module_generator.set_environment('BOOST_ROOT', self.installdir)
+        txt = super(EB_Boost, self).make_module_extra()
+        txt += self.module_generator.set_environment('BOOST_ROOT', self.installdir)
         return txt
     


### PR DESCRIPTION
have boost modules set up a BOOST_ROOT environment variable for use by e.g. cmake