### PR TITLE
Enable GCCcore as toolchain for clang, add logging, and fail if no proper prefix is found

### DIFF
--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -198,7 +198,19 @@ class EB_Clang(CMakeMake):
 
         # GCC and Clang are installed in different prefixes and Clang will not
         # find the GCC installation on its own.
-        self.cfg['configopts'] += "-DGCC_INSTALL_PREFIX='%s' " % get_software_root('GCC')
+        # First try with GCC
+        gcc_prefix = get_software_root('GCC')
+
+        # If that doesn't work, try with GCCcore
+        if gcc_prefix == None:
+            gcc_prefix = get_software_root('GCCcore')
+        
+        # If that doesn't work either, print error and exit
+        if gcc_prefix == None:
+            raise EasyBuildError("Can't find GCC prefix")
+
+        self.cfg['configopts'] += "-DGCC_INSTALL_PREFIX='%s' " % gcc_prefix
+        self.log.debug("Using %s as GCC_INSTALL_PREFIX" % gcc_prefix)
 
         self.cfg['configopts'] += "-DCMAKE_BUILD_TYPE=Release "
         if self.cfg['assertions']:

--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -207,7 +207,7 @@ class EB_Clang(CMakeMake):
             gcc_prefix = get_software_root('GCC')
         
         # If that doesn't work either, print error and exit
-        if gcc_prefix == None:
+        if gcc_prefix is None:
             raise EasyBuildError("Can't find GCC or GCCcore to use")
 
         self.cfg.update('configopts', "-DGCC_INSTALL_PREFIX='%s' " % gcc_prefix)

--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -198,16 +198,17 @@ class EB_Clang(CMakeMake):
 
         # GCC and Clang are installed in different prefixes and Clang will not
         # find the GCC installation on its own.
-        # First try with GCC
-        gcc_prefix = get_software_root('GCC')
+        # First try with GCCcore, as GCC built on top of GCCcore is just a wrapper for GCCcore and binutils,
+        # instead of a full-fledge compiler
+        gcc_prefix = get_software_root('GCCcore')
 
-        # If that doesn't work, try with GCCcore
+        # If that doesn't work, try with GCC
         if gcc_prefix == None:
-            gcc_prefix = get_software_root('GCCcore')
+            gcc_prefix = get_software_root('GCC')
         
         # If that doesn't work either, print error and exit
         if gcc_prefix == None:
-            raise EasyBuildError("Can't find GCC prefix")
+            raise EasyBuildError("Can't find GCC or GCCcore to use")
 
         self.cfg['configopts'] += "-DGCC_INSTALL_PREFIX='%s' " % gcc_prefix
         self.log.debug("Using %s as GCC_INSTALL_PREFIX" % gcc_prefix)

--- a/easybuild/easyblocks/c/clang.py
+++ b/easybuild/easyblocks/c/clang.py
@@ -203,15 +203,15 @@ class EB_Clang(CMakeMake):
         gcc_prefix = get_software_root('GCCcore')
 
         # If that doesn't work, try with GCC
-        if gcc_prefix == None:
+        if gcc_prefix is None:
             gcc_prefix = get_software_root('GCC')
         
         # If that doesn't work either, print error and exit
         if gcc_prefix == None:
             raise EasyBuildError("Can't find GCC or GCCcore to use")
 
-        self.cfg['configopts'] += "-DGCC_INSTALL_PREFIX='%s' " % gcc_prefix
-        self.log.debug("Using %s as GCC_INSTALL_PREFIX" % gcc_prefix)
+        self.cfg.update('configopts', "-DGCC_INSTALL_PREFIX='%s' " % gcc_prefix)
+        self.log.debug("Using %s as GCC_INSTALL_PREFIX", gcc_prefix)
 
         self.cfg['configopts'] += "-DCMAKE_BUILD_TYPE=Release "
         if self.cfg['assertions']:


### PR DESCRIPTION
This PR implements the following changes:

-Enables the use of `GCCcore` as base GCC for clang
-Adds logging to show which path was used as `GCC_INSTALL_PREFIX`
-If no correct path is found, it fails instead of keep going with `-DGCC_INSTALL_PREFIX='None'`