### PR TITLE
Update to easyblock for intel and imkl to handle the 2017 version of the compiler suite.

### DIFF
--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -296,10 +296,10 @@ class IntelBase(EasyBlock):
                 silent += 'COMPONENTS=%s\n' % self.install_components[0]
             elif self.install_components:
                 # a list of components is specified (needs quotes)
-		if LooseVersion(self.version) >= LooseVersion('2017.0.0'):
-		    silent += 'COMPONENTS=' + ';'.join(self.install_components) + '\n'
-		else:
-		    silent += 'COMPONENTS="' + ';'.join(self.install_components) + '"\n'
+                if LooseVersion(self.version) >= LooseVersion('2017.0.0'):
+                    silent += 'COMPONENTS=' + ';'.join(self.install_components) + '\n'
+                else:
+                    silent += 'COMPONENTS="' + ';'.join(self.install_components) + '"\n'
             else:
                 raise EasyBuildError("Empty list of matching components obtained via %s", self.cfg['components'])
 

--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -39,6 +39,7 @@ import re
 import shutil
 import tempfile
 import glob
+from distutils.version import LooseVersion
 
 import easybuild.tools.environment as env
 from easybuild.framework.easyblock import EasyBlock
@@ -295,7 +296,10 @@ class IntelBase(EasyBlock):
                 silent += 'COMPONENTS=%s\n' % self.install_components[0]
             elif self.install_components:
                 # a list of components is specified (needs quotes)
-                silent += 'COMPONENTS="' + ';'.join(self.install_components) + '"\n'
+		if LooseVersion(self.version) >= LooseVersion('2017.0.0'):
+		    silent += 'COMPONENTS=' + ';'.join(self.install_components) + '\n'
+		else:
+		    silent += 'COMPONENTS="' + ';'.join(self.install_components) + '"\n'
             else:
                 raise EasyBuildError("Empty list of matching components obtained via %s", self.cfg['components'])
 

--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -397,10 +397,10 @@ class EB_imkl(IntelBase):
                 if ver >= LooseVersion('10.3.4') and ver < LooseVersion('11.1'):
                     mkldirs += ['compiler/lib/intel64']
                 else:
-		    if ver >= LooseVersion('2017.0.0'):
-			mkldirs += ['lib/intel64_lin']
-		    else:
-			mkldirs += ['lib/intel64']
+                    if ver >= LooseVersion('2017.0.0'):
+                        mkldirs += ['lib/intel64_lin']
+                    else:
+                        mkldirs += ['lib/intel64']
 
         else:
             if self.cfg['m32']:

--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -397,7 +397,10 @@ class EB_imkl(IntelBase):
                 if ver >= LooseVersion('10.3.4') and ver < LooseVersion('11.1'):
                     mkldirs += ['compiler/lib/intel64']
                 else:
-                    mkldirs += ['lib/intel64']
+		    if ver >= LooseVersion('2017.0.0'):
+			mkldirs += ['lib/intel64_lin']
+		    else:
+			mkldirs += ['lib/intel64']
 
         else:
             if self.cfg['m32']:


### PR DESCRIPTION
This is an easyblock PR that goes with https://github.com/hpcugent/easybuild-easyconfigs/pull/3543 to make Intel 2017 installable.