### PR TITLE
give /lib preference over /lib64 & co, enable installation of libliberty by default

### DIFF
--- a/easybuild/easyblocks/b/binutils.py
+++ b/easybuild/easyblocks/b/binutils.py
@@ -161,7 +161,10 @@ class EB_binutils(ConfigureMake):
         }
 
         if self.cfg['install_libiberty']:
-            custom_paths['files'].extend([os.path.join('lib', 'libiberty.a'), os.path.join('include', 'libiberty.h')])
+            custom_paths['files'].extend([
+                (os.path.join('lib', 'libiberty.a'), os.path.join('lib64', 'libiberty.a')),
+                os.path.join('include', 'libiberty.h'),
+            ])
 
         # if zlib is listed as a dependency, it should get linked in statically
         if get_software_root('zlib'):

--- a/easybuild/easyblocks/b/binutils.py
+++ b/easybuild/easyblocks/b/binutils.py
@@ -155,6 +155,9 @@ class EB_binutils(ConfigureMake):
             'dirs': [],
         }
 
+        if self.cfg['install_libiberty']:
+            custom_paths['files'].extend([os.path.join('lib', 'libiberty.a'), os.path.join('include', 'libiberty.h')])
+
         # if zlib is listed as a dependency, it should get linked in statically
         if get_software_root('zlib'):
             for binary in binaries:

--- a/easybuild/easyblocks/b/binutils.py
+++ b/easybuild/easyblocks/b/binutils.py
@@ -32,7 +32,6 @@ import os
 import re
 from distutils.version import LooseVersion
 
-import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
@@ -113,11 +112,11 @@ class EB_binutils(ConfigureMake):
         if self.cfg['install_libiberty']:
             cflags = os.getenv('CFLAGS')
             if cflags:
-                env.setvar('CFLAGS', "%s -fPIC" % cflags)
+                self.cfg.update('buildopts', 'CFLAGS="$CFLAGS -fPIC"')
             else:
                 # if $CFLAGS is not defined, make sure we retain "-g -O2",
                 # since not specifying any optimization level implies -O0...
-                env.setvar('CFLAGS', "-g -O2 -fPIC")
+                self.cfg.update('buildopts', 'CFLAGS="-g -O2 -fPIC"')
 
     def install_step(self):
         """Install using 'make install', also install libiberty if desired."""

--- a/easybuild/easyblocks/b/binutils.py
+++ b/easybuild/easyblocks/b/binutils.py
@@ -122,15 +122,20 @@ class EB_binutils(ConfigureMake):
         """Install using 'make install', also install libiberty if desired."""
         super(EB_binutils, self).install_step()
 
-        # only install libiberty if it's not there yet; it is installed by default for old binutils versionsuffix
-        libiberty_installed = glob.glob(os.path.join(self.installdir, 'lib*', 'libiberty.a'))
-        if self.cfg['install_libiberty'] and not libiberty_installed:
-            copy_file(os.path.join(self.cfg['start_dir'], 'include', 'libiberty.h'),
-                      os.path.join(self.installdir, 'include', 'libiberty.h'))
-            copy_file(os.path.join(self.cfg['start_dir'], 'libiberty', 'libiberty.a'),
-                      os.path.join(self.installdir, 'lib', 'libiberty.a'))
-            copy_file(os.path.join(self.cfg['start_dir'], 'libiberty', 'libiberty.texi'),
-                      os.path.join(self.installdir, 'info', 'libiberty.texi'))
+        # only install libiberty files if if they're not there yet;
+        # libiberty.a is installed by default for old binutils versions
+        if self.cfg['install_libiberty']:
+            if not os.path.exists(os.path.join(self.installdir, 'include', 'libiberty.h')):
+                copy_file(os.path.join(self.cfg['start_dir'], 'include', 'libiberty.h'),
+                          os.path.join(self.installdir, 'include', 'libiberty.h'))
+
+            if not glob.glob(os.path.join(self.installdir, 'lib*', 'libiberty.a')):
+                copy_file(os.path.join(self.cfg['start_dir'], 'libiberty', 'libiberty.a'),
+                          os.path.join(self.installdir, 'lib', 'libiberty.a'))
+
+            if not os.path.exists(os.path.join(self.installdir, 'info', 'libiberty.texi')):
+                copy_file(os.path.join(self.cfg['start_dir'], 'libiberty', 'libiberty.texi'),
+                          os.path.join(self.installdir, 'info', 'libiberty.texi'))
 
     def sanity_check_step(self):
         """Custom sanity check for binutils."""

--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -45,6 +45,7 @@ import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.filetools import write_file
 from easybuild.tools.modules import get_software_root
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import check_os_dependency, get_os_name, get_os_type, get_shared_lib_ext, get_platform_name
@@ -60,6 +61,7 @@ class EB_GCC(ConfigureMake):
     def extra_options():
         extra_vars = {
             'languages': [[], "List of languages to build GCC for (--enable-languages)", CUSTOM],
+            'withlibiberty': [True, "Enable installing of libiberty", CUSTOM],
             'withlto': [True, "Enable LTO support", CUSTOM],
             'withcloog': [False, "Build GCC with CLooG support", CUSTOM],
             'withppl': [False, "Build GCC with PPL support", CUSTOM],
@@ -239,6 +241,10 @@ class EB_GCC(ConfigureMake):
         if self.cfg['languages']:
             self.configopts += " --enable-languages=%s" % ','.join(self.cfg['languages'])
 
+        # enable building of libiberty, if desired
+        if self.cfg['withlibiberty']:
+            self.configopts += "--enable-install-libiberty"
+
         # enable link-time-optimization (LTO) support, if desired
         if self.cfg['withlto']:
             self.configopts += " --enable-lto"
@@ -286,6 +292,12 @@ class EB_GCC(ConfigureMake):
             # set prefixes
             self.log.info("Performing regular GCC build...")
             configopts += " --prefix=%(p)s --with-local-prefix=%(p)s" % {'p': self.installdir}
+
+        # prioritize lib over lib{64,32,x32} for all architectures by overriding default MULTILIB_OSDIRNAMES config
+        cfgfile = 'gcc/config/i386/t-linux64'
+        multilib_osdirnames = "MULTILIB_OSDIRNAMES = m64=../lib:../lib64 m32=../lib:../lib32 mx32=../lib:../libx32"
+        self.log.info("Patching MULTILIB_OSDIRNAMES in %s with '%s'", cfgfile, multilib_osdirnames)
+        write_file(cfgfile, multilib_osdirnames, append=True)
 
         # III) create obj dir to build in, and change to it
         #     GCC doesn't like to be built in the source dir

--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -69,6 +69,7 @@ class EB_GCC(ConfigureMake):
             'pplwatchdog': [False, "Enable PPL watchdog", CUSTOM],
             'clooguseisl': [False, "Use ISL with CLooG or not", CUSTOM],
             'multilib': [False, "Build multilib gcc (both i386 and x86_64)", CUSTOM],
+            'prefer_lib_subdir': [True, "Configure GCC to prefer 'lib' subdirs over 'lib64' & co when linking", CUSTOM],
         }
         return ConfigureMake.extra_options(extra_vars)
 
@@ -294,10 +295,14 @@ class EB_GCC(ConfigureMake):
             configopts += " --prefix=%(p)s --with-local-prefix=%(p)s" % {'p': self.installdir}
 
         # prioritize lib over lib{64,32,x32} for all architectures by overriding default MULTILIB_OSDIRNAMES config
-        cfgfile = 'gcc/config/i386/t-linux64'
-        multilib_osdirnames = "MULTILIB_OSDIRNAMES = m64=../lib:../lib64 m32=../lib:../lib32 mx32=../lib:../libx32"
-        self.log.info("Patching MULTILIB_OSDIRNAMES in %s with '%s'", cfgfile, multilib_osdirnames)
-        write_file(cfgfile, multilib_osdirnames, append=True)
+        # only do this when multilib is not enabled
+        if self.cfg['prefer_lib_subdir'] and not self.cfg['multilib']:
+            cfgfile = 'gcc/config/i386/t-linux64'
+            multilib_osdirnames = "MULTILIB_OSDIRNAMES = m64=../lib:../lib64 m32=../lib:../lib32 mx32=../lib:../libx32"
+            self.log.info("Patching MULTILIB_OSDIRNAMES in %s with '%s'", cfgfile, multilib_osdirnames)
+            write_file(cfgfile, multilib_osdirnames, append=True)
+        elif self.cfg['multilib']:
+            self.log.info("Not patching MULTILIB_OSDIRNAMES since use of --enable-multilib is enabled")
 
         # III) create obj dir to build in, and change to it
         #     GCC doesn't like to be built in the source dir

--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -243,7 +243,7 @@ class EB_GCC(ConfigureMake):
 
         # enable building of libiberty, if desired
         if self.cfg['withlibiberty']:
-            self.configopts += "--enable-install-libiberty"
+            self.configopts += " --enable-install-libiberty"
 
         # enable link-time-optimization (LTO) support, if desired
         if self.cfg['withlto']:

--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -61,7 +61,7 @@ class EB_GCC(ConfigureMake):
     def extra_options():
         extra_vars = {
             'languages': [[], "List of languages to build GCC for (--enable-languages)", CUSTOM],
-            'withlibiberty': [True, "Enable installing of libiberty", CUSTOM],
+            'withlibiberty': [False, "Enable installing of libiberty", CUSTOM],
             'withlto': [True, "Enable LTO support", CUSTOM],
             'withcloog': [False, "Build GCC with CLooG support", CUSTOM],
             'withppl': [False, "Build GCC with PPL support", CUSTOM],


### PR DESCRIPTION
See suggestion in #921 by @sebth on giving preference to `/lib` subdirectories, and #969 by @stachon suggesting to enable the installation of `libiberty`.

I'm going to test https://github.com/hpcugent/easybuild-easyconfigs/pull/3776, https://github.com/hpcugent/easybuild-easyconfigs/pull/3777 and https://github.com/hpcugent/easybuild-easyconfigs/pull/3778 on top of this PR.