### PR TITLE
avoid CMake fiddling with the RPATHs injected by EasyBuild via --rpath

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -96,10 +96,15 @@ class CMakeMake(ConfigureMake):
             if value is not None:
                 options.append("-D%s='%s'" % (option, value))
 
-        # show what CMake is doing by default
-        options.append("-DCMAKE_VERBOSE_MAKEFILE=ON")
+        if build_option('rpath'):
+            # instruct CMake not to fiddle with RPATH when --rpath is used, since it will undo stuff on install...
+            # https://github.com/LLNL/spack/blob/0f6a5cd38538e8969d11bd2167f11060b1f53b43/lib/spack/spack/build_environment.py#L416
+            options.append('-DCMAKE_SKIP_RPATH=ON')
 
-        options_string = " ".join(options)
+        # show what CMake is doing by default
+        options.append('-DCMAKE_VERBOSE_MAKEFILE=ON')
+
+        options_string = ' '.join(options)
 
         command = "%s cmake %s %s %s" % (self.cfg['preconfigopts'], srcdir, options_string, self.cfg['configopts'])
         (out, _) = run_cmd(command, log_all=True, simple=False)

--- a/easybuild/easyblocks/m/metis.py
+++ b/easybuild/easyblocks/m/metis.py
@@ -37,7 +37,8 @@ from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import mkdir
+from easybuild.tools.config import build_option
+from easybuild.tools.filetools import apply_regex_substitutions, mkdir
 from easybuild.tools.run import run_cmd
 
 
@@ -47,13 +48,16 @@ class EB_METIS(ConfigureMake):
     def __init__(self, *args, **kwargs):
         """Define custom class variables for METIS."""
         super(EB_METIS, self).__init__(*args, **kwargs)
-
         self.lib_exts = []
 
     def configure_step(self, *args, **kwargs):
         """Configure build using 'make config' (only for recent versions (>= v5))."""
 
         if LooseVersion(self.version) >= LooseVersion("5"):
+
+            if build_option('rpath'):
+                # patch Makefile to tell CMake not to wipe the RPATHs we inject...
+                apply_regex_substitutions('Makefile', [(r'^(CONFIG_FLAGS\s*=\s*)', r'\1-DCMAKE_SKIP_RPATH=ON ')])
 
             cmd = "make %s config prefix=%s" % (self.cfg['configopts'], self.installdir)
             run_cmd(cmd, log_all=True, simple=True)
@@ -77,7 +81,7 @@ class EB_METIS(ConfigureMake):
         """
         Install by manually copying files to install dir, for old versions,
         or by running 'make install' for new versions.
-        
+
         Create symlinks where expected by other applications
         (in Lib instead of lib)
         """

--- a/easybuild/easyblocks/m/metis.py
+++ b/easybuild/easyblocks/m/metis.py
@@ -57,7 +57,7 @@ class EB_METIS(ConfigureMake):
 
             if build_option('rpath'):
                 # patch Makefile to tell CMake not to wipe the RPATHs we inject...
-                apply_regex_substitutions('Makefile', [(r'^(CONFIG_FLAGS\s*=\s*)', r'\1-DCMAKE_SKIP_RPATH=ON ')])
+                apply_regex_substitutions('Makefile', [(r'^(CONFIG_FLAGS\s*=\s*)', r'\1 -DCMAKE_SKIP_RPATH=ON ')])
 
             cmd = "make %s config prefix=%s" % (self.cfg['configopts'], self.installdir)
             run_cmd(cmd, log_all=True, simple=True)


### PR DESCRIPTION
Passing `-DCMAKE_SKIP_RPATH=ON` when using `--rpath` is required to avoid that CMake strips *all* RPATHs from the built binaries/libraries before actually installing them (which it does by default, urgh).

Required to get METIS to build in conjunction with `--rpath` (cfr. https://github.com/hpcugent/easybuild-framework/pull/1942).