### PR TITLE
don't enable prefer_lib_subdir by default in GCC easyblock

### DIFF
--- a/easybuild/easyblocks/g/gcc.py
+++ b/easybuild/easyblocks/g/gcc.py
@@ -69,7 +69,7 @@ class EB_GCC(ConfigureMake):
             'pplwatchdog': [False, "Enable PPL watchdog", CUSTOM],
             'clooguseisl': [False, "Use ISL with CLooG or not", CUSTOM],
             'multilib': [False, "Build multilib gcc (both i386 and x86_64)", CUSTOM],
-            'prefer_lib_subdir': [True, "Configure GCC to prefer 'lib' subdirs over 'lib64' & co when linking", CUSTOM],
+            'prefer_lib_subdir': [False, "Configure GCC to prefer 'lib' subdirs over 'lib64' & co when linking", CUSTOM],
         }
         return ConfigureMake.extra_options(extra_vars)
 


### PR DESCRIPTION
This was enabled by default in #1030 with the intention of making sure that `/lib` subdirectories of the dependencies that were installed with EasyBuild get preference over `/usr/lib64`.

However, it has the side-effect of also preferring `/usr/lib` over `/usr/lib64`, which leads to problem like these:

* GCC (see also https://github.com/hpcugent/easybuild-easyconfigs/pull/3801):

```
/usr/lib/crti.o: could not read symbols: File in wrong format
collect2: ld returned 1 exit status
```

with:

```
$ file /usr/lib/crti.o
/usr/lib/crti.o: ELF 32-bit LSB relocatable, Intel 80386, version 1 (SYSV), not stripped
```

* MPICH, MVAPICH & other MPI libraries, if 32-bit BLCR is installed system-wide:

```
/usr/lib/libcr.so: could not read symbols: File in wrong format
```

with

```
$ file /usr/lib/libcr.so
/usr/lib/libcr.so: symbolic link to `libcr.so.0.5.5'
$ file /usr/lib/libcr.so.0.5.5
/usr/lib/libcr.so.0.5.5: ELF 32-bit LSB shared object, Intel 80386, version 1 (SYSV), dynamically linked, stripped
```

I think we probably *could* enable this by default for sufficiently recent versions of `binutils` (which are potentially smart enough to skip incompatible libraries), but I'm not 100% sure, and I don't have time to figure this out right now.

cc @sebth, @geimer (you mentioned something about side effects in #921... ;-))
