### PR TITLE
also build Boost MPI library in parallel

### DIFF
--- a/easybuild/easyblocks/b/boost.py
+++ b/easybuild/easyblocks/b/boost.py
@@ -178,7 +178,7 @@ class EB_Boost(EasyBlock):
 
             # build mpi lib first
             # let bjam know about the user-config.jam file we created in the configure step
-            run_cmd("./bjam %s %s" % bjammpioptions, paracmd, log_all=True, simple=True)
+            run_cmd("./bjam %s %s" % (bjammpioptions, paracmd), log_all=True, simple=True)
 
             # boost.mpi was built, let's 'install' it now
             run_cmd("./bjam %s  install %s" % (bjammpioptions, paracmd), log_all=True, simple=True)

--- a/easybuild/easyblocks/b/boost.py
+++ b/easybuild/easyblocks/b/boost.py
@@ -178,7 +178,7 @@ class EB_Boost(EasyBlock):
 
             # build mpi lib first
             # let bjam know about the user-config.jam file we created in the configure step
-            run_cmd("./bjam %s" % bjammpioptions, log_all=True, simple=True)
+            run_cmd("./bjam %s %s" % bjammpioptions, paracmd, log_all=True, simple=True)
 
             # boost.mpi was built, let's 'install' it now
             run_cmd("./bjam %s  install %s" % (bjammpioptions, paracmd), log_all=True, simple=True)


### PR DESCRIPTION
wrapper PR for #1011 by @dolfim, fixes typo in adding parallel option to `bjam` command