### PR TITLE
always specify name of serial Fortran compiler to ALADIN, it already knows to use MPI wrapper commands

### DIFF
--- a/easybuild/easyblocks/a/aladin.py
+++ b/easybuild/easyblocks/a/aladin.py
@@ -74,7 +74,7 @@ class EB_ALADIN(EasyBlock):
         if 'LIBRARY_PATH' in os.environ:
             self.log.debug("Unsetting $LIBRARY_PATH (was: %s)" % os.environ['LIBRARY_PATH'])
             self.orig_library_path = os.environ.pop('LIBRARY_PATH')
-        
+
         # build auxiliary libraries
         auxlibs_dir = None
 
@@ -131,7 +131,7 @@ class EB_ALADIN(EasyBlock):
                  }
 
             run_cmd_qa("./build_gmkpack", qa)
- 
+
             os.chdir(cwd)
 
             paths = os.getenv('PATH').split(':')
@@ -241,7 +241,7 @@ class EB_ALADIN(EasyBlock):
 
         stdqa = OrderedDict([
             (r'Confirm library .* is .*', 'y'),  # this one needs to be tried first!
-            (r'.*fortran 90 compiler name .*\s*:\n\(suggestions\s*: .*\)', os.getenv('F90')),
+            (r'.*fortran 90 compiler name .*\s*:\n\(suggestions\s*: .*\)', f90_seq),
             (r'.*fortran 90 compiler interfaced with .*\s*:\n\(suggestions\s*: .*\)', f90_seq),
             (r'Please type the ABSOLUTE name of .*library.*, or ignore\s*[:]*\s*[\n]*.*', ''),
             (r'Please .* to save this draft configuration file :\n.*', '%s.x' % self.conf_file),


### PR DESCRIPTION
This is partially to deal with the backward-incompatible change/bug fix from https://github.com/hpcugent/easybuild-framework/pull/2005.