### PR TITLE
Boost

### DIFF
--- a/easybuild/easyblocks/b/boost.py
+++ b/easybuild/easyblocks/b/boost.py
@@ -157,16 +157,8 @@ class EB_Boost(EasyBlock):
                 else: 
                     raise EasyBuildError("Bailing out: only PrgEnv-gnu supported for now")
             elif self.cfg['b2']:
-                # use MPI from EB toolchain
-                mpilibs = [os.getenv('EBROOTMPIC'),os.getenv("EBROOTOPENMPI"),os.getenv("EBROOTGOMPI")]
-                if len(mpilibs):
-                    for mpi in mpilibs:
-                        if mpi is not None:
-                            self.log.info('found: MPI libraries from environement: %s'% mpi)
-                            txt += 'using mpi : %s ;\n' % mpi
-                            break
-                else:
-                    raise EasyBuildError("Failed to find MPI in toolchain")
+                # b2 will find MPI libraries; Be sure that your EB toolchain contains MPI support
+                txt = 'using mpi ;\n'
             else:
                 txt = "using mpi : %s ;\n" % os.getenv("MPICXX")
 


### PR DESCRIPTION
bjam has been superseded by b2 since Boost 1.47.  This patch adds the option of using b2 for building Boost. This patch changes the default behavior of using MPIC wrapper from the environment for MPI. b2 is much better about finding MPI libraries than bjam.  MPI should be defined with EB toolchain and not from the OS.
"b2 = True" must be specified in easyconfig to enable this new feature. Otherwise, the default bjam will be used. This will ensure that older of versions of Boost will build the same as they always have.
I have tested this with Boost-1.62 on Ubuntu 14.04 and Ubuntu 16.04 with foss-2016b (OPENMPI)
This should be reviewed by someone who is more knowledgeable about Boost than I am.