### PR TITLE
Pass CXXFLAGS and LDFLAGS to Boost Bjam

### DIFF
--- a/easybuild/easyblocks/b/boost.py
+++ b/easybuild/easyblocks/b/boost.py
@@ -159,9 +159,14 @@ class EB_Boost(EasyBlock):
     def build_step(self):
         """Build Boost with bjam tool."""
 
-        cxxflags = os.environ['CXXFLAGS']
-        ldflags = os.environ['LDFLAGS']
-        bjamoptions = " --prefix=%s cxxflags='%s' linkflags='%s'" % (self.objdir, cxxflags, ldflags)
+        bjamoptions = " --prefix=%s" % self.objdir
+
+        cxxflags = os.getenv('CXXFLAGS')
+        if cxxflags is not None:
+            bjamoptions += " cxxflags='%s'" % cxxflags 
+        ldflags = os.getenv('LDFLAGS')
+        if ldflags is not None:
+            bjamoptions += " linkflags='%s'" % ldflags 
 
         # specify path for bzip2/zlib if module is loaded
         for lib in ["bzip2", "zlib"]:

--- a/easybuild/easyblocks/b/boost.py
+++ b/easybuild/easyblocks/b/boost.py
@@ -161,7 +161,7 @@ class EB_Boost(EasyBlock):
 
         cxxflags = os.environ['CXXFLAGS']
         ldflags = os.environ['LDFLAGS']
-        bjamoptions = " --prefix=%s cxxflags='%s' ='%s'" % (self.objdir, ldflags)
+        bjamoptions = " --prefix=%s cxxflags='%s' linkflags='%s'" % (self.objdir, cxxflags, ldflags)
 
         # specify path for bzip2/zlib if module is loaded
         for lib in ["bzip2", "zlib"]:

--- a/easybuild/easyblocks/b/boost.py
+++ b/easybuild/easyblocks/b/boost.py
@@ -35,6 +35,7 @@ EasyBuild support for Boost, implemented as an easyblock
 @author: Luca Marsella (CSCS)
 @author: Guilherme Peretti-Pezzi (CSCS)
 @author: Joachim Hein (Lund University)
+@author: Michele Dolfi (ETH Zurich)
 """
 from distutils.version import LooseVersion
 import fileinput
@@ -158,7 +159,9 @@ class EB_Boost(EasyBlock):
     def build_step(self):
         """Build Boost with bjam tool."""
 
-        bjamoptions = " --prefix=%s" % self.objdir
+        cxxflags = os.environ['CXXFLAGS']
+        ldflags = os.environ['LDFLAGS']
+        bjamoptions = " --prefix=%s cxxflags='%s' ='%s'" % (self.objdir, ldflags)
 
         # specify path for bzip2/zlib if module is loaded
         for lib in ["bzip2", "zlib"]:


### PR DESCRIPTION
This makes the easyblock more consistent with the others and specially allows to change the C++ std just using the toolchainopt.