### PR TITLE
don't pass empty string as custom installopts for numpy in test_step

### DIFF
--- a/easybuild/easyblocks/n/numpy.py
+++ b/easybuild/easyblocks/n/numpy.py
@@ -63,7 +63,6 @@ class EB_numpy(FortranPythonPackage):
 
         self.sitecfg = None
         self.sitecfgfn = 'site.cfg'
-        self.installopts = ''
         self.testinstall = True
         self.testcmd = "cd .. && %(python)s -c 'import numpy; numpy.test(verbose=2)'"
 
@@ -221,7 +220,7 @@ class EB_numpy(FortranPythonPackage):
         for pylibdir in abs_pylibdirs:
             mkdir(pylibdir, parents=True)
         pythonpath = "export PYTHONPATH=%s &&" % os.pathsep.join(abs_pylibdirs + ['$PYTHONPATH'])
-        cmd = self.compose_install_command(tmpdir, extrapath=pythonpath, installopts=self.installopts)
+        cmd = self.compose_install_command(tmpdir, extrapath=pythonpath)
         run_cmd(cmd, log_all=True, simple=True, verbose=False)
 
         try:


### PR DESCRIPTION
`self.installopts` is initialized as empty and never touched again in the `numpy` easyblock

It is then used to pass down custom `installopts` to `compose_install_command` in `test_step`, which makes the `installopts is None` check in `PythonPackage.test_step` fail, causing `self.cfg['installopts']` not to be used

This is a problem when `numpy` is being installed with `pip`, since it means that `--ignore-installed` (cfr. #1066) will not be passed down when the temporary installation of `numpy` to run the tests on is being installed, resulting in the `numpy` being part of the `Python` installation being removed...