### PR TITLE
Cleanup build before proceeding with full Boost

### DIFF
--- a/easybuild/easyblocks/b/boost.py
+++ b/easybuild/easyblocks/b/boost.py
@@ -190,6 +190,9 @@ class EB_Boost(EasyBlock):
 
             # boost.mpi was built, let's 'install' it now
             run_cmd("./bjam %s  install %s" % (bjammpioptions, paracmd), log_all=True, simple=True)
+            
+            # cleanup previous build before proceeding with the full Boost
+            run_cmd("./bjam --clean-all", log_all=True, simple=True)
 
         # install remainder of boost libraries
         self.log.info("Installing boost libraries")


### PR DESCRIPTION
While porting the easyconfig to Boost 1.63 I got failures like:
```
error: Name clash for '...'
error: 
error: Tried to build the target twice, with property sets having 
error: these incompabile properties:
error: ...
```