### PR TITLE
add custom easyblock for FFTW (REVIEW)

### DIFF
--- a/easybuild/easyblocks/f/fftw.py
+++ b/easybuild/easyblocks/f/fftw.py
@@ -34,11 +34,11 @@ from easybuild.tools.systemtools import X86_64, get_cpu_features
 from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
 
 
-# SSE2, AVX* (x86_64 only)
-FFTW_CPU_FEATURE_FLAGS_SINGLE_DOUBLE = ['avx', 'avx2', 'avx512', 'sse2']
+# AVX*, FMA, SSE2 (x86_64 only)
+FFTW_CPU_FEATURE_FLAGS_SINGLE_DOUBLE = ['avx', 'avx2', 'avx512', 'fma', 'sse2']
 # Altivec (POWER), SSE (x86), NEON (ARM), FMA (x86_64)
 # asimd is CPU feature for extended NEON on AARCH64
-FFTW_CPU_FEATURE_FLAGS = FFTW_CPU_FEATURE_FLAGS_SINGLE_DOUBLE + ['altivec', 'asimd', 'fma', 'neon', 'sse']
+FFTW_CPU_FEATURE_FLAGS = FFTW_CPU_FEATURE_FLAGS_SINGLE_DOUBLE + ['altivec', 'asimd', 'neon', 'sse']
 FFTW_PRECISION_FLAGS = ['single', 'double', 'long-double', 'quad-precision']
 
 
@@ -129,7 +129,10 @@ class EB_FFTW(ConfigureMake):
                 if prec in ['single', 'double']:
                     for flag in FFTW_CPU_FEATURE_FLAGS_SINGLE_DOUBLE:
                         if getattr(self, flag):
-                            prec_configopts.append('--enable-%s' % flag)
+                            if flag == 'fma':
+                                prec_configopts.append('--enable-avx-128-fma')
+                            else:
+                                prec_configopts.append('--enable-%s' % flag)
 
                 # Altivec (POWER) and SSE only for single precision
                 for flag in ['altivec', 'sse']:
@@ -139,10 +142,6 @@ class EB_FFTW(ConfigureMake):
                 # NEON (ARM) only for single precision and double precision (on AARCH64)
                 if (prec == 'single' and self.neon) or (prec == 'double' and self.asimd):
                     prec_configopts.append('--enable-neon')
-
-                # FMA support (only on recent x86_64)
-                if self.fma:
-                    prec_configopts.append('--enable-avx-128-fma')
 
                 # append additional configure options (may be empty string, but that's OK)
                 self.cfg.update('configopts', [' '.join(prec_configopts) + common_config_opts])

--- a/easybuild/easyblocks/f/fftw.py
+++ b/easybuild/easyblocks/f/fftw.py
@@ -1,0 +1,175 @@
+##
+# Copyright 2009-2017 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# http://github.com/hpcugent/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for building and installing FFTW, implemented as an easyblock
+"""
+from vsc.utils.missing import nub
+
+from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.systemtools import X86_64, get_cpu_features
+
+
+FFTW_CPU_FEATURE_FLAGS = ['avx', 'avx2', 'avx512', 'sse2']
+FFTW_PRECISION_FLAGS = ['single', 'double', 'long-double', 'quad-precision']
+
+
+class EB_FFTW(ConfigureMake):
+    """Support for building/installing FFTW."""
+
+    @staticmethod
+    def _prec_param(prec):
+        """Determine parameter name for specified precision"""
+        return 'with_%s_prec' % prec.replace('-', '_').replace('_precision', '')
+
+    @staticmethod
+    def extra_options():
+        """Custom easyconfig parameters for FFTW."""
+        extra_vars = {
+            'with_mpi': [True, "Enable building of FFTW MPI library", CUSTOM],
+            'with_openmp': [True, "Enable building of FFTW OpenMP library", CUSTOM],
+            'with_threads': [True, "Enable building of FFTW threads library", CUSTOM],
+        }
+
+        for flag in FFTW_CPU_FEATURE_FLAGS:
+            help_msg = "Configure with --enable-%s (if None, auto-detect support for %s)" % (flag, flag.upper())
+            extra_vars['use_%s' % flag] = [None, help_msg, CUSTOM]
+
+        for prec in FFTW_PRECISION_FLAGS:
+            help_msg = "Enable building of %s precision library" % prec.replace('-precision', '')
+            extra_vars[EB_FFTW._prec_param(prec)] = [True, help_msg, CUSTOM]
+
+        return ConfigureMake.extra_options(extra_vars)
+
+    def __init__(self, *args, **kwargs):
+        """Initialisation of custom class variables for FFTW."""
+        super(EB_FFTW, self).__init__(*args, **kwargs)
+
+        for flag in FFTW_CPU_FEATURE_FLAGS:
+            # fail-safe: make sure we're not overwriting an existing attribute (could lead to weird bugs if we do)
+            if hasattr(self, flag):
+                raise EasyBuildError("EasyBlock attribute '%s' already exists")
+            setattr(self, flag, self.cfg['use_%s' % flag])
+
+        cpu_features = get_cpu_features()
+
+        # on macOS, AVX is indicated with 'avx1.0' rather than 'avx'
+        if 'avx1.0' in cpu_features:
+            cpu_features.append('avx')
+
+        self.log.info("List of CPU features: %s", cpu_features)
+
+        # auto-detect CPU features that can be used and are not enabled/disabled explicitly
+        for flag in FFTW_CPU_FEATURE_FLAGS:
+            if getattr(self, flag) is None and flag in cpu_features:
+                self.log.info("Enabling use of %s (should be supported based on CPU features)", flag.upper())
+                setattr(self, flag, True)
+
+    def run_all_steps(self, *args, **kwargs):
+        """
+        Put configure options in place for different precisions (single, double, long double, quad).
+        """
+        # keep track of configopts specified in easyconfig file, so we can include them in each iteration later
+        common_config_opts = self.cfg['configopts']
+
+        self.cfg['configopts'] = []
+
+        for prec in FFTW_PRECISION_FLAGS:
+            if self.cfg[EB_FFTW._prec_param(prec)]:
+
+                prec_configopts = []
+
+                # double precison is the default, no configure flag needed (there is no '--enable-double')
+                if prec != 'double':
+                    prec_configopts.append('--enable-%s' % prec)
+
+                # MPI is not supported for quad precision
+                if prec != 'quad-precision' and self.cfg['with_mpi']:
+                    prec_configopts.append('--enable-mpi')
+
+                if self.toolchain.options['pic']:
+                    prec_configopts.append('--with-pic')
+
+                for libtype in ['openmp', 'threads']:
+                    if self.cfg['with_%s' % libtype]:
+                        prec_configopts.append('--enable-%s' % libtype)
+
+                # SSE2, AVX* only supported for single/double precision
+                if prec in ['single', 'double']:
+                    for flag in FFTW_CPU_FEATURE_FLAGS:
+                        if getattr(self, flag):
+                            prec_configopts.append('--enable-%s' % flag)
+
+                # append additional configure options (may be empty string, but that's OK)
+                self.cfg.update('configopts', [' '.join(prec_configopts) + common_config_opts])
+
+        self.log.debug("List of configure options to iterate over: %s", self.cfg['configopts'])
+
+        return super(EB_FFTW, self).run_all_steps(*args, **kwargs)
+
+    def sanity_check_step(self):
+        """Custom sanity check for FFTW."""
+
+        custom_paths = {
+            'files': ['bin/fftw-wisdom-to-conf', 'include/fftw3.f', 'include/fftw3.h'],
+            'dirs': ['lib/pkgconfig'],
+        }
+
+        extra_files = []
+        for (prec, letter) in [('double', ''), ('long_double', 'l'), ('quad', 'q'), ('single', 'f')]:
+            if self.cfg['with_%s_prec' % prec]:
+
+                # precision-specific binaries
+                extra_files.append('bin/fftw%s-wisdom' % letter)
+
+                # precision-specific .f03 header files
+                inc_f03 = 'include/fftw3%s.f03' % letter
+                if prec == 'single':
+                    # no separate .f03 header file for single/double precision
+                    inc_f03 = 'include/fftw3.f03'
+                extra_files.append(inc_f03)
+
+                # libraries, one for each precision and variant (if enabled)
+                for variant in ['', 'mpi', 'openmp', 'threads']:
+                    if variant == 'openmp':
+                        suff = '_omp'
+                    elif variant == '':
+                        suff = ''
+                    else:
+                        suff = '_' + variant
+
+                    # MPI is not compatible with quad precision
+                    if variant == '' or self.cfg['with_%s' % variant] and not (prec == 'quad' and variant == 'mpi'):
+                        extra_files.append('lib/libfftw3%s%s.a' % (letter, suff))
+
+        # some additional files to check for when MPI is enabled
+        if self.cfg['with_mpi']:
+            extra_files.extend(['include/fftw3-mpi.f03', 'include/fftw3-mpi.h'])
+            if self.cfg['with_long_double_prec']:
+                extra_files.append('include/fftw3l-mpi.f03')
+
+        custom_paths['files'].extend(nub(extra_files))
+
+        super(EB_FFTW, self).sanity_check_step(custom_paths=custom_paths)

--- a/easybuild/easyblocks/f/fftw.py
+++ b/easybuild/easyblocks/f/fftw.py
@@ -32,7 +32,8 @@ from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.systemtools import X86_64, get_cpu_features
 
 
-FFTW_CPU_FEATURE_FLAGS = ['avx', 'avx2', 'avx512', 'sse2']
+FFTW_CPU_FEATURE_FLAGS_X84_64 = ['avx', 'avx2', 'avx512', 'sse2']
+FFTW_CPU_FEATURE_FLAGS = FFTW_CPU_FEATURE_FLAGS_X84_64 + ['altivec']
 FFTW_PRECISION_FLAGS = ['single', 'double', 'long-double', 'quad-precision']
 
 
@@ -118,9 +119,13 @@ class EB_FFTW(ConfigureMake):
 
                 # SSE2, AVX* only supported for single/double precision
                 if prec in ['single', 'double']:
-                    for flag in FFTW_CPU_FEATURE_FLAGS:
+                    for flag in FFTW_CPU_FEATURE_FLAGS_X86_64:
                         if getattr(self, flag):
                             prec_configopts.append('--enable-%s' % flag)
+
+                # Altivec (POWER) only for single precision
+                if prec == 'single' and self.altivec:
+                    prec_configopts.append('--enable-altivec')
 
                 # append additional configure options (may be empty string, but that's OK)
                 self.cfg.update('configopts', [' '.join(prec_configopts) + common_config_opts])

--- a/easybuild/easyblocks/f/fftw.py
+++ b/easybuild/easyblocks/f/fftw.py
@@ -140,7 +140,7 @@ class EB_FFTW(ConfigureMake):
                         prec_configopts.append('--enable-%s' % flag)
 
                 # NEON (ARM) only for single precision and double precision (on AARCH64)
-                if (prec == 'single' and self.neon) or (prec == 'double' and self.asimd):
+                if (prec == 'single' and (self.asimd or self.neon)) or (prec == 'double' and self.asimd):
                     prec_configopts.append('--enable-neon')
 
                 # append additional configure options (may be empty string, but that's OK)

--- a/easybuild/easyblocks/f/fftw.py
+++ b/easybuild/easyblocks/f/fftw.py
@@ -32,8 +32,8 @@ from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.systemtools import X86_64, get_cpu_features
 
 
-FFTW_CPU_FEATURE_FLAGS_X84_64 = ['avx', 'avx2', 'avx512', 'sse2']
-FFTW_CPU_FEATURE_FLAGS = FFTW_CPU_FEATURE_FLAGS_X84_64 + ['altivec']
+FFTW_CPU_FEATURE_FLAGS_X86_64 = ['avx', 'avx2', 'avx512', 'sse2']
+FFTW_CPU_FEATURE_FLAGS = FFTW_CPU_FEATURE_FLAGS_X86_64 + ['altivec']
 FFTW_PRECISION_FLAGS = ['single', 'double', 'long-double', 'quad-precision']
 
 

--- a/easybuild/easyblocks/f/fftw.py
+++ b/easybuild/easyblocks/f/fftw.py
@@ -24,6 +24,8 @@
 ##
 """
 EasyBuild support for building and installing FFTW, implemented as an easyblock
+
+@author: Kenneth Hoste (HPC-UGent)
 """
 from vsc.utils.missing import nub
 
@@ -35,7 +37,7 @@ from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
 
 
 # AVX*, FMA, SSE2 (x86_64 only)
-FFTW_CPU_FEATURE_FLAGS_SINGLE_DOUBLE = ['avx', 'avx2', 'avx512', 'fma', 'sse2']
+FFTW_CPU_FEATURE_FLAGS_SINGLE_DOUBLE = ['avx', 'avx2', 'avx512', 'fma', 'sse2', 'vsx']
 # Altivec (POWER), SSE (x86), NEON (ARM), FMA (x86_64)
 # asimd is CPU feature for extended NEON on AARCH64
 FFTW_CPU_FEATURE_FLAGS = FFTW_CPU_FEATURE_FLAGS_SINGLE_DOUBLE + ['altivec', 'asimd', 'neon', 'sse']

--- a/easybuild/easyblocks/f/fftw.py
+++ b/easybuild/easyblocks/f/fftw.py
@@ -29,7 +29,9 @@ from vsc.utils.missing import nub
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.config import build_option
 from easybuild.tools.systemtools import X86_64, get_cpu_features
+from easybuild.tools.toolchain.compiler import OPTARCH_GENERIC
 
 
 FFTW_CPU_FEATURE_FLAGS_X86_64 = ['avx', 'avx2', 'avx512', 'sse2']
@@ -82,11 +84,13 @@ class EB_FFTW(ConfigureMake):
 
         self.log.info("List of CPU features: %s", cpu_features)
 
-        # auto-detect CPU features that can be used and are not enabled/disabled explicitly
-        for flag in FFTW_CPU_FEATURE_FLAGS:
-            if getattr(self, flag) is None and flag in cpu_features:
-                self.log.info("Enabling use of %s (should be supported based on CPU features)", flag.upper())
-                setattr(self, flag, True)
+        # auto-detect CPU features that can be used and are not enabled/disabled explicitly,
+        # but only if --optarch=GENERIC is not being used
+        if build_option('optarch') != OPTARCH_GENERIC:
+            for flag in FFTW_CPU_FEATURE_FLAGS:
+                if getattr(self, flag) is None and flag in cpu_features:
+                    self.log.info("Enabling use of %s (should be supported based on CPU features)", flag.upper())
+                    setattr(self, flag, True)
 
     def run_all_steps(self, *args, **kwargs):
         """


### PR DESCRIPTION
This easyblock takes care of building FFTW with use of AVX* instructions enabled when suitable, i.e. when the host on which it is being built supports these instructions.

(note: requires https://github.com/hpcugent/easybuild-framework/pull/2074)

Using this easyblock for building FFTW results in the same multi-cycle build as is currently done in the FFTW easyconfigs (by specifying `configopts` as a list):

```
$ eb FFTW.eb -x | grep configure_step -A 1
[configure_step method]
  running command " ./configure --prefix=/Users/kehoste/.local/easybuild/software/FFTW/3.3.5-gompi-2017a --enable-single --enable-mpi --with-pic --enable-openmp --enable-threads --enable-avx --enable-avx2 --enable-sse2"
--
[configure_step method]
  running command " ./configure --prefix=/Users/kehoste/.local/easybuild/software/FFTW/3.3.5-gompi-2017a --enable-mpi --with-pic --enable-openmp --enable-threads --enable-avx --enable-avx2 --enable-sse2"
--
[configure_step method]
  running command " ./configure --prefix=/Users/kehoste/.local/easybuild/software/FFTW/3.3.5-gompi-2017a --enable-long-double --enable-mpi --with-pic --enable-openmp --enable-threads"
--
[configure_step method]
  running command " ./configure --prefix=/Users/kehoste/.local/easybuild/software/FFTW/3.3.5-gompi-2017a --enable-quad-precision --with-pic --enable-openmp --enable-threads"
```

The use of advanced SIMD instructions (SSE2, AVX*), building of the libraries for different precisions and for MPI/OpenMP/threads can be controlled via custom easyconfig parameters supported by this easyblock, see below.

```
$ eb -e EB_FFTW -a

...

EASYBLOCK-SPECIFIC
------------------
...
use_avx*                 Configure with --enable-avx (if None, auto-detect support for AVX) [default: None]
use_avx2*                Configure with --enable-avx2 (if None, auto-detect support for AVX2) [default: None]
use_avx512*              Configure with --enable-avx512 (if None, auto-detect support for AVX512) [default: None]
use_sse2*                Configure with --enable-sse2 (if None, auto-detect support for SSE2) [default: None]
with_double_prec*        Enable building of double precision library [default: True]
with_long_double_prec*   Enable building of long-double precision library [default: True]
with_mpi*                Enable building of FFTW MPI library [default: True]
with_openmp*             Enable building of FFTW OpenMP library [default: True]
with_quad_prec*          Enable building of quad precision library [default: True]
with_single_prec*        Enable building of single precision library [default: True]
with_threads*            Enable building of FFTW threads library [default: True]

...
```

Example easyconfig to use along with this easyblock (`eb FFTW.eb --include-easyblocks fftw.py`):

```python
name = 'FFTW'
version = '3.3.5'

homepage = 'http://www.fftw.org'
description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
 in one or more dimensions, of arbitrary input size, and of both real and complex data."""

toolchain = {'name': 'gompi', 'version': '2016b'}
toolchainopts = {'pic': True}

sources = [SOURCELOWER_TAR_GZ]
source_urls = [homepage]

moduleclass = 'numlib'
```

TODO:

* [x] take into account `--optarch` (in particular `--optarch=GENERIC`)
* [x] extend to also auto-detecting for ARM (`neon`, `asimd`) and POWER (`altivec`) (thoughts on this @geimer, @JackPerdue?)

cc: @akesandgren, @jhein32, @wpoely86, @rjeschmi, @verdurin