### PR TITLE
changed the sanity check for 2016b since the directory structure has …

### DIFF
--- a/easybuild/easyblocks/m/mcr.py
+++ b/easybuild/easyblocks/m/mcr.py
@@ -119,16 +119,17 @@ class EB_MCR(EasyBlock):
 
     def sanity_check_step(self):
         """Custom sanity check for MCR."""
-        if self.version == "2016b":
-            custom_paths = {
-                'files': [],
-                'dirs': [os.path.join(self.subdir, x, 'glnxa64') for x in ['bin', 'cefclient/sys/os']],
-            }
+        custom_paths = {
+            'files': [],
+            'dirs': [os.path.join(self.subdir, 'bin', 'glnxa64')],
+        }
+        if LooseVersion(self.version) >= LooseVersion('2016b'):
+            custom_paths.append(os.path.join(self.subdir, 'cefclient', 'sys', 'os', 'glnxa64'))
         else:
-            custom_paths = {
-                'files': [],
-                'dirs': [os.path.join(self.subdir, x, 'glnxa64') for x in ['runtime', 'bin', 'sys/os']],
-            }
+            custom_paths.extend([
+                os.path.join(self.subdir, 'runtime', 'glnxa64'),
+                os.path.join(self.subdir, 'sys', 'os', 'glnxa64'),
+            ])
         super(EB_MCR, self).sanity_check_step(custom_paths=custom_paths)
 
     def make_module_extra(self):

--- a/easybuild/easyblocks/m/mcr.py
+++ b/easybuild/easyblocks/m/mcr.py
@@ -71,6 +71,7 @@ class EB_MCR(EasyBlock):
         if LooseVersion(self.version) < LooseVersion('R2015a'):
             shutil.copyfile(os.path.join(self.cfg['start_dir'], 'installer_input.txt'), configfile)
             config = read_file(configfile)
+            # compile regex first since re.sub doesn't accept re.M flag for multiline regex in Python 2.6
             regdest = re.compile(r"^# destinationFolder=.*", re.M)
             regagree = re.compile(r"^# agreeToLicense=.*", re.M)
             regmode = re.compile(r"^# mode=.*", re.M)

--- a/easybuild/easyblocks/m/mcr.py
+++ b/easybuild/easyblocks/m/mcr.py
@@ -119,10 +119,16 @@ class EB_MCR(EasyBlock):
 
     def sanity_check_step(self):
         """Custom sanity check for MCR."""
-        custom_paths = {
-            'files': [],
-            'dirs': [os.path.join(self.subdir, x, 'glnxa64') for x in ['runtime', 'bin', 'sys/os']],
-        }
+        if self.version == "2016b":
+            custom_paths = {
+                'files': [],
+                'dirs': [os.path.join(self.subdir, x, 'glnxa64') for x in ['bin', 'cefclient/sys/os']],
+            }
+        else:
+            custom_paths = {
+                'files': [],
+                'dirs': [os.path.join(self.subdir, x, 'glnxa64') for x in ['runtime', 'bin', 'sys/os']],
+            }
         super(EB_MCR, self).sanity_check_step(custom_paths=custom_paths)
 
     def make_module_extra(self):

--- a/easybuild/easyblocks/m/mcr.py
+++ b/easybuild/easyblocks/m/mcr.py
@@ -68,7 +68,7 @@ class EB_MCR(EasyBlock):
         """Configure MCR installation: create license file."""
 
         configfile = os.path.join(self.builddir, self.configfilename)
-        if LooseVersion(self.version) < LooseVersion('2015a'):
+        if LooseVersion(self.version) < LooseVersion('R2015a'):
             shutil.copyfile(os.path.join(self.cfg['start_dir'], 'installer_input.txt'), configfile)
             config = read_file(configfile)
             config = re.sub(r"^# destinationFolder=.*", "destinationFolder=%s" % self.installdir, config, re.M)
@@ -123,7 +123,7 @@ class EB_MCR(EasyBlock):
             'files': [],
             'dirs': [os.path.join(self.subdir, 'bin', 'glnxa64')],
         }
-        if LooseVersion(self.version) >= LooseVersion('2016b'):
+        if LooseVersion(self.version) >= LooseVersion('R2016b'):
             custom_paths['dirs'].append(os.path.join(self.subdir, 'cefclient', 'sys', 'os', 'glnxa64'))
         else:
             custom_paths['dirs'].extend([

--- a/easybuild/easyblocks/m/mcr.py
+++ b/easybuild/easyblocks/m/mcr.py
@@ -71,9 +71,13 @@ class EB_MCR(EasyBlock):
         if LooseVersion(self.version) < LooseVersion('R2015a'):
             shutil.copyfile(os.path.join(self.cfg['start_dir'], 'installer_input.txt'), configfile)
             config = read_file(configfile)
-            config = re.sub(r"^# destinationFolder=.*", "destinationFolder=%s" % self.installdir, config, re.M)
-            config = re.sub(r"^# agreeToLicense=.*", "agreeToLicense=Yes", config, re.M)
-            config = re.sub(r"^# mode=.*", "mode=silent", config, re.M)
+            regdest = re.compile(r"^# destinationFolder=.*", re.M)
+            regagree = re.compile(r"^# agreeToLicense=.*", re.M)
+            regmode = re.compile(r"^# mode=.*", re.M)
+
+            config = regdest.sub("destinationFolder=%s" % self.installdir, config)
+            config = regagree.sub("agreeToLicense=Yes", config)
+            config = regmode.sub("mode=silent", config)
         else:
             config = '\n'.join([
                 "destinationFolder=%s" % self.installdir,

--- a/easybuild/easyblocks/m/mcr.py
+++ b/easybuild/easyblocks/m/mcr.py
@@ -124,9 +124,9 @@ class EB_MCR(EasyBlock):
             'dirs': [os.path.join(self.subdir, 'bin', 'glnxa64')],
         }
         if LooseVersion(self.version) >= LooseVersion('2016b'):
-            custom_paths.append(os.path.join(self.subdir, 'cefclient', 'sys', 'os', 'glnxa64'))
+            custom_paths['dirs'].append(os.path.join(self.subdir, 'cefclient', 'sys', 'os', 'glnxa64'))
         else:
-            custom_paths.extend([
+            custom_paths['dirs'].extend([
                 os.path.join(self.subdir, 'runtime', 'glnxa64'),
                 os.path.join(self.subdir, 'sys', 'os', 'glnxa64'),
             ])


### PR DESCRIPTION
MCR R2016b fails to build only because the sanity checks are no longer valid. I added a condition to have the right sanity checks for this version specifically. 