### PR TITLE
Bundle: Allow per-component source_urls with templating

### DIFF
--- a/easybuild/easyblocks/generic/bundle.py
+++ b/easybuild/easyblocks/generic/bundle.py
@@ -95,6 +95,10 @@ class Bundle(EasyBlock):
             else:
                 raise EasyBuildError("No sources specification for component %d v%d", comp_name, comp_version)
 
+            if 'source_urls' in comp_specs:
+                # add per-component source_urls to list of bundle source_urls, expanding templates
+                self.cfg.update('source_urls', cfg['source_urls'])
+
             self.comp_cfgs.append(cfg)
 
         self.cfg.enable_templating = True


### PR DESCRIPTION
Including a package with template-dependent `source_urls` in a bundle doesn't work.  If specified on the bundle level, the templating resolves to the bundle's values, which is in most cases plain wrong.  This PR allows to specify per-component `source_urls` with the templates resolved to the component's values.