### PR TITLE
Qt: Use '-prefix <path>' rather than '--prefix=<path>' for configure

### DIFF
--- a/easybuild/easyblocks/q/qt.py
+++ b/easybuild/easyblocks/q/qt.py
@@ -76,7 +76,7 @@ class EB_Qt(ConfigureMake):
         else:
             raise EasyBuildError("Don't know which platform to set based on compiler family.")
 
-        cmd = "%s ./configure --prefix=%s %s" % (self.cfg['preconfigopts'], self.installdir, self.cfg['configopts'])
+        cmd = "%s ./configure -prefix %s %s" % (self.cfg['preconfigopts'], self.installdir, self.cfg['configopts'])
         qa = {
             "Type 'o' if you want to use the Open Source Edition.": 'o',
             "Do you accept the terms of either license?": 'yes',


### PR DESCRIPTION
Passing `--prefix=<path>` to `configure` leads to a hard error with Qt 5.8.0.  After checking the `configure --help` output of Qt 3.1.0, Qt 4.8.7, and Qt 5.8.0, it seems that `-prefix <path>` is the correct syntax (which was probably silently converted by versions prior to 5.8.0).