### PR TITLE
add support for installing Intel tools that do not require license at installation time, incl. impi and imkl 2017.2.174

### DIFF
--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -112,6 +112,7 @@ class IntelBase(EasyBlock):
         extra_vars = EasyBlock.extra_options(extra_vars)
         extra_vars.update({
             'license_activation': [ACTIVATION_LIC_SERVER, "License activation type", CUSTOM],
+            'licensed': [True, "Set to False if Intel software does not require a runtime licence", CUSTOM],
             # 'usetmppath':
             # workaround for older SL5 version (5.5 and earlier)
             # used to be True, but False since SL5.6/SL6
@@ -206,32 +207,33 @@ class IntelBase(EasyBlock):
         """Custom prepare step for IntelBase. Set up the license"""
         super(IntelBase, self).prepare_step()
 
-        default_lic_env_var = 'INTEL_LICENSE_FILE'
-        lic_specs, self.license_env_var = find_flexlm_license(custom_env_vars=[default_lic_env_var],
-                                                              lic_specs=[self.cfg['license_file']])
+        if self.cfg['licensed']:
+            default_lic_env_var = 'INTEL_LICENSE_FILE'
+            lic_specs, self.license_env_var = find_flexlm_license(custom_env_vars=[default_lic_env_var],
+                                                                  lic_specs=[self.cfg['license_file']])
 
-        if lic_specs:
-            if self.license_env_var is None:
-                self.log.info("Using Intel license specifications from 'license_file': %s", lic_specs)
-                self.license_env_var = default_lic_env_var
+            if lic_specs:
+                if self.license_env_var is None:
+                    self.log.info("Using Intel license specifications from 'license_file': %s", lic_specs)
+                    self.license_env_var = default_lic_env_var
+                else:
+                    self.log.info("Using Intel license specifications from $%s: %s", self.license_env_var, lic_specs)
+
+                self.license_file = os.pathsep.join(lic_specs)
+                env.setvar(self.license_env_var, self.license_file)
+
+                # if we have multiple retained lic specs, specify to 'use a license which exists on the system'
+                if len(lic_specs) > 1:
+                    self.log.debug("More than one license specs found, using '%s' license activation instead of '%s'",
+                                   ACTIVATION_EXIST_LIC, self.cfg['license_activation'])
+                    self.cfg['license_activation'] = ACTIVATION_EXIST_LIC
+
+                    # $INTEL_LICENSE_FILE should always be set during installation with existing license
+                    env.setvar(default_lic_env_var, self.license_file)
             else:
-                self.log.info("Using Intel license specifications from $%s: %s", self.license_env_var, lic_specs)
-
-            self.license_file = os.pathsep.join(lic_specs)
-            env.setvar(self.license_env_var, self.license_file)
-
-            # if we have multiple retained lic specs, specify to 'use a license which exists on the system'
-            if len(lic_specs) > 1:
-                self.log.debug("More than one license specs found, using '%s' license activation instead of '%s'",
-                               ACTIVATION_EXIST_LIC, self.cfg['license_activation'])
-                self.cfg['license_activation'] = ACTIVATION_EXIST_LIC
-
-                # $INTEL_LICENSE_FILE should always be set during installation with existing license
-                env.setvar(default_lic_env_var, self.license_file)
-        else:
-            msg = "No viable license specifications found; "
-            msg += "specify 'license_file', or define $INTEL_LICENSE_FILE or $LM_LICENSE_FILE"
-            raise EasyBuildError(msg)
+                msg = "No viable license specifications found; "
+                msg += "specify 'license_file', or define $INTEL_LICENSE_FILE or $LM_LICENSE_FILE"
+                raise EasyBuildError(msg)
 
     def configure_step(self):
         """Configure: handle license file and clean home dir."""
@@ -260,31 +262,38 @@ class IntelBase(EasyBlock):
         if silent_cfg_names_map is None:
             silent_cfg_names_map = {}
 
-        # license file entry is only applicable with license file or server type of activation
-        # also check whether specified activation type makes sense
-        lic_file_server_activations = [ACTIVATION_LIC_FILE, ACTIVATION_LIC_SERVER]
-        other_activations = [act for act in ACTIVATION_TYPES if act not in lic_file_server_activations]
-        lic_file_entry = ""
-        if self.cfg['license_activation'] in lic_file_server_activations:
-            lic_file_entry = "%(license_file_name)s=%(license_file)s"
-        elif not self.cfg['license_activation'] in other_activations:
-            raise EasyBuildError("Unknown type of activation specified: %s (known :%s)",
-                                 self.cfg['license_activation'], ACTIVATION_TYPES)
+        if self.cfg['licensed']:
+            # license file entry is only applicable with license file or server type of activation
+            # also check whether specified activation type makes sense
+            lic_file_server_activations = [ACTIVATION_LIC_FILE, ACTIVATION_LIC_SERVER]
+            other_activations = [act for act in ACTIVATION_TYPES if act not in lic_file_server_activations]
+            lic_file_entry = ""
+            if self.cfg['license_activation'] in lic_file_server_activations:
+                lic_file_entry = "%(license_file_name)s=%(license_file)s"
+            elif not self.cfg['license_activation'] in other_activations:
+                raise EasyBuildError("Unknown type of activation specified: %s (known :%s)",
+                                     self.cfg['license_activation'], ACTIVATION_TYPES)
+            silent = '\n'.join([
+                "%(activation_name)s=%(activation)s",
+                lic_file_entry,
+                ""  # Add a newline at the end, so we can easily append if needed
+            ]) % {
+                'activation_name': silent_cfg_names_map.get('activation_name', ACTIVATION_NAME),
+                'license_file_name': silent_cfg_names_map.get('license_file_name', LICENSE_FILE_NAME),
+                'activation': self.cfg['license_activation'],
+                'license_file': self.license_file,
+            }
+        else:
+            silent = '\n'
 
-        silent = '\n'.join([
-            "%(activation_name)s=%(activation)s",
-            lic_file_entry,
+        silent = silent.join([
             "%(install_dir_name)s=%(install_dir)s",
             "ACCEPT_EULA=accept",
             "%(install_mode_name)s=%(install_mode)s",
             "CONTINUE_WITH_OPTIONAL_ERROR=yes",
             ""  # Add a newline at the end, so we can easily append if needed
         ]) % {
-            'activation_name': silent_cfg_names_map.get('activation_name', ACTIVATION_NAME),
-            'license_file_name': silent_cfg_names_map.get('license_file_name', LICENSE_FILE_NAME),
             'install_dir_name': silent_cfg_names_map.get('install_dir_name', INSTALL_DIR_NAME),
-            'activation': self.cfg['license_activation'],
-            'license_file': self.license_file,
             'install_dir': silent_cfg_names_map.get('install_dir', self.installdir),
             'install_mode': silent_cfg_names_map.get('install_mode', INSTALL_MODE_2015),
             'install_mode_name': silent_cfg_names_map.get('install_mode_name', INSTALL_MODE_NAME_2015),

--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -111,8 +111,8 @@ class IntelBase(EasyBlock):
     def extra_options(extra_vars=None):
         extra_vars = EasyBlock.extra_options(extra_vars)
         extra_vars.update({
-            'license_activation': [ACTIVATION_LIC_SERVER,
-                                   "License activation type (can be set to False if no activation required)", CUSTOM],
+            'license_activation': [ACTIVATION_LIC_SERVER, "License activation type", CUSTOM],
+            'licensed': [True, "Set to False if Intel software does not require a runtime licence", CUSTOM],
             # 'usetmppath':
             # workaround for older SL5 version (5.5 and earlier)
             # used to be True, but False since SL5.6/SL6
@@ -207,7 +207,7 @@ class IntelBase(EasyBlock):
         """Custom prepare step for IntelBase. Set up the license"""
         super(IntelBase, self).prepare_step()
 
-        if self.cfg['license_activation']:
+        if self.cfg['licensed']:
             default_lic_env_var = 'INTEL_LICENSE_FILE'
             lic_specs, self.license_env_var = find_flexlm_license(custom_env_vars=[default_lic_env_var],
                                                                   lic_specs=[self.cfg['license_file']])
@@ -262,7 +262,7 @@ class IntelBase(EasyBlock):
         if silent_cfg_names_map is None:
             silent_cfg_names_map = {}
 
-        if self.cfg['license_activation']:
+        if self.cfg['licensed']:
             # license file entry is only applicable with license file or server type of activation
             # also check whether specified activation type makes sense
             lic_file_server_activations = [ACTIVATION_LIC_FILE, ACTIVATION_LIC_SERVER]
@@ -284,8 +284,7 @@ class IntelBase(EasyBlock):
                 'license_file': self.license_file,
             }
         else:
-            self.log.debug("Easyconfig variable 'license_activation' set to False, ignoring license checks"
-                           % (self.cfg['license_activation']))
+            self.log.debug("Easyconfig variable 'licenced' set to %s, ignoring license checks" % (self.cfg['licensed']))
             silent = '\n'
 
         silent = silent.join([
@@ -383,7 +382,7 @@ class IntelBase(EasyBlock):
         """Custom variable definitions in module file."""
         txt = super(IntelBase, self).make_module_extra()
 
-        if self.cfg['license_activation']:
+        if self.cfg['licensed']:
             txt += self.module_generator.prepend_paths(self.license_env_var, [self.license_file],
                                                        allow_abs=True, expand_relpaths=False)
 

--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -284,6 +284,7 @@ class IntelBase(EasyBlock):
                 'license_file': self.license_file,
             }
         else:
+            self.log.debug("Easyconfig variable 'licenced' set to %s, ignoring license checks" % (self.cfg['licensed']))
             silent = '\n'
 
         silent = silent.join([

--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -112,7 +112,8 @@ class IntelBase(EasyBlock):
         extra_vars = EasyBlock.extra_options(extra_vars)
         extra_vars.update({
             'license_activation': [ACTIVATION_LIC_SERVER, "License activation type", CUSTOM],
-            'licensed': [True, "Set to False if Intel software does not require a runtime licence", CUSTOM],
+            'requires_runtime_license': [True, "Set to False if Intel software does not require a runtime licence",
+                                         CUSTOM],
             # 'usetmppath':
             # workaround for older SL5 version (5.5 and earlier)
             # used to be True, but False since SL5.6/SL6
@@ -203,11 +204,17 @@ class IntelBase(EasyBlock):
         except OSError, err:
             raise EasyBuildError("Failed to symlink %s to %s: %s", self.home_subdir_local, self.home_subdir, err)
 
-    def prepare_step(self):
+    def prepare_step(self, requires_runtime_license=True):
         """Custom prepare step for IntelBase. Set up the license"""
         super(IntelBase, self).prepare_step()
 
-        if self.cfg['licensed']:
+        # Decide if we need a license or not
+        if not self.cfg['requires_runtime_license'] or not requires_runtime_license:
+            self.requires_runtime_license = False
+        else:
+            self.requires_runtime_license = True
+
+        if self.requires_runtime_license:
             default_lic_env_var = 'INTEL_LICENSE_FILE'
             lic_specs, self.license_env_var = find_flexlm_license(custom_env_vars=[default_lic_env_var],
                                                                   lic_specs=[self.cfg['license_file']])
@@ -262,7 +269,7 @@ class IntelBase(EasyBlock):
         if silent_cfg_names_map is None:
             silent_cfg_names_map = {}
 
-        if self.cfg['licensed']:
+        if self.requires_runtime_license:
             # license file entry is only applicable with license file or server type of activation
             # also check whether specified activation type makes sense
             lic_file_server_activations = [ACTIVATION_LIC_FILE, ACTIVATION_LIC_SERVER]
@@ -284,7 +291,10 @@ class IntelBase(EasyBlock):
                 'license_file': self.license_file,
             }
         else:
-            self.log.debug("Easyconfig variable 'licenced' set to %s, ignoring license checks" % (self.cfg['licensed']))
+            self.log.debug(
+                "Ignoring license checks: self.requires_runtime_license=%s self.cfg['requires_runtime_license']=%s"
+                % (self.requires_runtime_license, self.cfg['requires_runtime_license'])
+            )
             silent = '\n'
 
         silent = silent.join([
@@ -382,7 +392,7 @@ class IntelBase(EasyBlock):
         """Custom variable definitions in module file."""
         txt = super(IntelBase, self).make_module_extra()
 
-        if self.cfg['licensed']:
+        if self.requires_runtime_license:
             txt += self.module_generator.prepend_paths(self.license_env_var, [self.license_file],
                                                        allow_abs=True, expand_relpaths=False)
 

--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -111,8 +111,8 @@ class IntelBase(EasyBlock):
     def extra_options(extra_vars=None):
         extra_vars = EasyBlock.extra_options(extra_vars)
         extra_vars.update({
-            'license_activation': [ACTIVATION_LIC_SERVER, "License activation type", CUSTOM],
-            'licensed': [True, "Set to False if Intel software does not require a runtime licence", CUSTOM],
+            'license_activation': [ACTIVATION_LIC_SERVER,
+                                   "License activation type (can be set to False if no activation required)", CUSTOM],
             # 'usetmppath':
             # workaround for older SL5 version (5.5 and earlier)
             # used to be True, but False since SL5.6/SL6
@@ -207,7 +207,7 @@ class IntelBase(EasyBlock):
         """Custom prepare step for IntelBase. Set up the license"""
         super(IntelBase, self).prepare_step()
 
-        if self.cfg['licensed']:
+        if self.cfg['license_activation']:
             default_lic_env_var = 'INTEL_LICENSE_FILE'
             lic_specs, self.license_env_var = find_flexlm_license(custom_env_vars=[default_lic_env_var],
                                                                   lic_specs=[self.cfg['license_file']])
@@ -262,7 +262,7 @@ class IntelBase(EasyBlock):
         if silent_cfg_names_map is None:
             silent_cfg_names_map = {}
 
-        if self.cfg['licensed']:
+        if self.cfg['license_activation']:
             # license file entry is only applicable with license file or server type of activation
             # also check whether specified activation type makes sense
             lic_file_server_activations = [ACTIVATION_LIC_FILE, ACTIVATION_LIC_SERVER]
@@ -284,7 +284,8 @@ class IntelBase(EasyBlock):
                 'license_file': self.license_file,
             }
         else:
-            self.log.debug("Easyconfig variable 'licenced' set to %s, ignoring license checks" % (self.cfg['licensed']))
+            self.log.debug("Easyconfig variable 'license_activation' set to False, ignoring license checks"
+                           % (self.cfg['license_activation']))
             silent = '\n'
 
         silent = silent.join([
@@ -382,7 +383,7 @@ class IntelBase(EasyBlock):
         """Custom variable definitions in module file."""
         txt = super(IntelBase, self).make_module_extra()
 
-        if self.cfg['licensed']:
+        if self.cfg['license_activation']:
             txt += self.module_generator.prepend_paths(self.license_env_var, [self.license_file],
                                                        allow_abs=True, expand_relpaths=False)
 

--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -381,8 +381,9 @@ class IntelBase(EasyBlock):
         """Custom variable definitions in module file."""
         txt = super(IntelBase, self).make_module_extra()
 
-        txt += self.module_generator.prepend_paths(self.license_env_var, [self.license_file],
-                                                   allow_abs=True, expand_relpaths=False)
+        if self.cfg['licensed']:
+            txt += self.module_generator.prepend_paths(self.license_env_var, [self.license_file],
+                                                       allow_abs=True, expand_relpaths=False)
 
         if self.cfg['m32']:
             nlspath = os.path.join('idb', '32', 'locale', '%l_%t', '%N')

--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -115,7 +115,7 @@ class IntelBase(EasyBlock):
         extra_vars = EasyBlock.extra_options(extra_vars)
         extra_vars.update({
             'license_activation': [ACTIVATION_LIC_SERVER, "License activation type", CUSTOM],
-            'requires_runtime_license': [True, "Set to False if Intel software does not require a runtime licence",
+            'requires_runtime_license': [True, "Boolean indicating whether or not a runtime license is required",
                                          CUSTOM],
             # 'usetmppath':
             # workaround for older SL5 version (5.5 and earlier)
@@ -291,13 +291,10 @@ class IntelBase(EasyBlock):
                 'license_file': self.license_file,
             }
         else:
-            self.log.debug(
-                "Ignoring license checks: self.requires_runtime_license=%s self.cfg['requires_runtime_license']=%s"
-                % (self.requires_runtime_license, self.cfg['requires_runtime_license'])
-            )
-            silent = '\n'
+            self.log.debug("No license required, so not including license specifications in silent.cfg")
+            silent = ''
 
-        silent = silent.join([
+        silent += '\n'.join([
             "%(install_dir_name)s=%(install_dir)s",
             "ACCEPT_EULA=accept",
             "%(install_mode_name)s=%(install_mode)s",

--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -208,11 +208,8 @@ class IntelBase(EasyBlock):
         """Custom prepare step for IntelBase. Set up the license"""
         super(IntelBase, self).prepare_step()
 
-        # Decide if we need a license or not
-        if not self.cfg['requires_runtime_license'] or not requires_runtime_license:
-            self.requires_runtime_license = False
-        else:
-            self.requires_runtime_license = True
+        # Decide if we need a license or not (default is True because of defaults of individual Booleans)
+        self.requires_runtime_license = self.cfg['requires_runtime_license'] and requires_runtime_license
 
         if self.requires_runtime_license:
             default_lic_env_var = 'INTEL_LICENSE_FILE'

--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -101,6 +101,9 @@ class IntelBase(EasyBlock):
         self.license_file = 'UNKNOWN'
         self.license_env_var = 'UNKNOWN'
 
+        # Initialise whether we need a runtime licence or not
+        self.requires_runtime_license = True
+
         self.home_subdir = os.path.join(os.getenv('HOME'), 'intel')
         common_tmp_dir = os.path.dirname(tempfile.gettempdir())  # common tmp directory, same across nodes
         self.home_subdir_local = os.path.join(common_tmp_dir, os.getenv('USER'), 'easybuild_intel')

--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -73,9 +73,9 @@ class EB_imkl(IntelBase):
 
     def prepare_step(self):
         if LooseVersion(self.version) >= LooseVersion('2017.2.174'):
-            IntelBase.prepare_step(self, requires_runtime_license=False)
+            super(EB_imkl, self).prepare_step(requires_runtime_license=False)
         else:
-            IntelBase.prepare_step(self)
+            super(EB_imkl, self).prepare_step()
 
     def install_step(self):
         """

--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -71,6 +71,12 @@ class EB_imkl(IntelBase):
         # make sure $MKLROOT isn't set, it's known to cause problems with the installation
         self.cfg.update('unwanted_env_vars', ['MKLROOT'])
 
+    def prepare_step(self):
+        if LooseVersion(self.version) >= LooseVersion('2017.2.174'):
+            IntelBase.prepare_step(self, requires_runtime_license=False)
+        else:
+            IntelBase.prepare_step(self)
+
     def install_step(self):
         """
         Actual installation

--- a/easybuild/easyblocks/i/impi.py
+++ b/easybuild/easyblocks/i/impi.py
@@ -60,9 +60,9 @@ class EB_impi(IntelBase):
 
     def prepare_step(self):
         if LooseVersion(self.version) >= LooseVersion('2017.2.174'):
-            super(EB_imkl, self).prepare_step(requires_runtime_license=False)
+            super(EB_impi, self).prepare_step(requires_runtime_license=False)
         else:
-            super(EB_imkl, self).prepare_step()
+            super(EB_impi, self).prepare_step()
 
     def install_step(self):
         """

--- a/easybuild/easyblocks/i/impi.py
+++ b/easybuild/easyblocks/i/impi.py
@@ -58,6 +58,12 @@ class EB_impi(IntelBase):
         }
         return IntelBase.extra_options(extra_vars)
 
+    def prepare_step(self):
+        if LooseVersion(self.version) >= LooseVersion('2017.2.174'):
+            super(EB_imkl, self).prepare_step(requires_runtime_license=False)
+        else:
+            super(EB_imkl, self).prepare_step()
+
     def install_step(self):
         """
         Actual installation


### PR DESCRIPTION
Just add a new variable `licensed` to the intelbase to switch off licence related stuff