### PR TITLE
remove prefix_opt as custom easyconfig paramter for Qt since -prefix is hardcoded

### DIFF
--- a/easybuild/easyblocks/q/qt.py
+++ b/easybuild/easyblocks/q/qt.py
@@ -48,7 +48,12 @@ class EB_Qt(ConfigureMake):
         extra_vars = {
              'platform': [None, "Target platform to build for (e.g. linux-g++-64, linux-icc-64)", CUSTOM],
         }
-        return ConfigureMake.extra_options(extra_vars)
+        extra_vars = ConfigureMake.extra_options(extra_vars)
+
+        # allowing to specify prefix_opt doesn't make sense for Qt, since -prefix is hardcoded in configure_step
+        del extra_vars['prefix_opt']
+
+        return extra_vars
 
     def configure_step(self):
         """Configure Qt using interactive `configure` script."""


### PR DESCRIPTION
See remark by @lucamar in #1119

cc @geimer

without this patch:

```
$ eb -e EB_Qt -a | grep 'EASYBLOCK-SPECIFIC' -A 5
EASYBLOCK-SPECIFIC
------------------
configure_cmd_prefix*   Prefix to be glued before ./configure [default: ""]
platform*               Target platform to build for (e.g. linux-g++-64, linux-icc-64) [default: None]
prefix_opt*             Prefix command line option for configure script ('--prefix=' if None) [default: None]
tar_config_opts*        Override tar settings as determined by configure. [default: False]
```

with this patch:

```
$ eb -e EB_Qt -a | grep 'EASYBLOCK-SPECIFIC' -A 4
EASYBLOCK-SPECIFIC
------------------
configure_cmd_prefix*   Prefix to be glued before ./configure [default: ""]
platform*               Target platform to build for (e.g. linux-g++-64, linux-icc-64) [default: None]
tar_config_opts*        Override tar settings as determined by configure. [default: False]
```