### PR TITLE
Reduce number of environment variables in icc and ifort modules.

### DIFF
--- a/easybuild/easyblocks/i/icc.py
+++ b/easybuild/easyblocks/i/icc.py
@@ -141,6 +141,7 @@ class EB_icc(IntelBase):
             'IDB_HOME': ['bin/intel64'],
             'IPPROOT': ['ipp'],
             'LD_LIBRARY_PATH': ['lib'],
+            'LIBRARY_PATH': ['lib'],
             'MANPATH': ['debugger/gdb/intel64/share/man', 'man/common', 'man/en_US', 'share/man'],
             'PATH': [],
             'TBBROOT': ['tbb'],
@@ -149,6 +150,7 @@ class EB_icc(IntelBase):
         if self.cfg['m32']:
             # 32-bit toolchain
             guesses['PATH'].extend(['bin/ia32', 'tbb/bin/ia32'])
+            # in the end we set 'LIBRARY_PATH' equal to 'LD_LIBRARY_PATH'
             guesses['LD_LIBRARY_PATH'].append('lib/ia32')
 
         else:
@@ -162,6 +164,7 @@ class EB_icc(IntelBase):
                 'tbb/bin/intel64',
             ])
 
+            # in the end we set 'LIBRARY_PATH' equal to 'LD_LIBRARY_PATH'
             guesses['LD_LIBRARY_PATH'].extend([
                 'compiler/lib/intel64',
                 'debugger/ipt/intel64/lib',
@@ -193,6 +196,8 @@ class EB_icc(IntelBase):
             # 'lib/intel64' is deliberately listed last, so it gets precedence over subdirs
             guesses['LD_LIBRARY_PATH'].append('lib/intel64')
 
+        guesses['LIBRARY_PATH'] = guesses['LD_LIBRARY_PATH']
+
         # set debugger path
         if self.debuggerpath:
             guesses['PATH'].append(os.path.join(self.debuggerpath, 'gdb', 'intel64', 'bin'))
@@ -210,7 +215,7 @@ class EB_icc(IntelBase):
         for guess in guesses['IDB_HOME']:
             if os.path.isfile(os.path.join(self.installdir, guess, 'idb')):
                 idb_found = True
-                exit
+                break
         if not idb_found:
             del guesses['IDB_HOME']
 


### PR DESCRIPTION
This change gives the following resulting diff in the module file:

```diff
@@ -11,21 +11,8 @@
 load("binutils/2.26")
 prepend_path("MODULEPATH", "/home/boldeman/.local/easybuild/modules/all/Compiler/intel/2016.3.210-GCC-5.4.0-2.26")

-prepend_path("IDB_HOME", pathJoin(root, "compilers_and_libraries_2016.3.210/linux/bin/intel64"))
-prepend_path("LD_LIBRARY_PATH", pathJoin(root, "lib"))
-prepend_path("LD_LIBRARY_PATH", pathJoin(root, "lib/intel64"))
 prepend_path("LD_LIBRARY_PATH", pathJoin(root, "compilers_and_libraries_2016.3.210/linux/compiler/lib/intel64"))
-prepend_path("LD_LIBRARY_PATH", pathJoin(root, "compilers_and_libraries_2016.3.210/linux/compiler/lib/intel64"))
-prepend_path("LIBRARY_PATH", pathJoin(root, "lib"))
-prepend_path("LIBRARY_PATH", pathJoin(root, "lib/intel64"))
-prepend_path("LIBRARY_PATH", pathJoin(root, "compilers_and_libraries_2016.3.210/linux/compiler/lib/intel64"))
-prepend_path("LIBRARY_PATH", pathJoin(root, "compilers_and_libraries_2016.3.210/linux/compiler/lib/intel64"))
-prepend_path("MANPATH", pathJoin(root, "man"))
-prepend_path("MANPATH", pathJoin(root, "man/common"))
-prepend_path("MANPATH", pathJoin(root, "compilers_and_libraries_2016.3.210/linux/man"))
 prepend_path("MANPATH", pathJoin(root, "compilers_and_libraries_2016.3.210/linux/man/common"))
-prepend_path("PATH", pathJoin(root, "bin"))
-prepend_path("PATH", pathJoin(root, "compilers_and_libraries_2016.3.210/linux/bin"))
 prepend_path("PATH", pathJoin(root, "compilers_and_libraries_2016.3.210/linux/bin/intel64"))
 setenv("EBROOTICC", root)
 setenv("EBVERSIONICC", "2016.3.210")
```

* Remove IDB_HOME if idb does not exist (removed with later Intel compiler: replaced by gdb)
* The root/lib LD_LIBRARY_PATH only contains directories, no libraries.
* The root/lib/intel64 is a symlink to the same place as compilers_and_libraries_2016.3.210/linux/compiler/lib/intel64
* The last LD_LIBRARY_PATH is a duplicate
* LIBRARY_PATH is not necessary: icc and ifort already include those paths automatically when compiling
* For MANPATH: without common there are no manpages there; the other two are symlinks to the same place
* Only one of the 4 MANPATHs contains the manual pages
* Only one of the 3 PATHs contains all the binaries we need

This setup is more consistent with Intel's own compilervars.sh.