### PR TITLE
[intelbase, pgi, totalview] Allow list of license files/servers via 'license_file' easyconfig parameter

### DIFF
--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -44,6 +44,7 @@ from distutils.version import LooseVersion
 import easybuild.tools.environment as env
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.framework.easyconfig.types import ensure_iterable_license_specs
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import find_flexlm_license, read_file
 from easybuild.tools.run import run_cmd
@@ -215,17 +216,8 @@ class IntelBase(EasyBlock):
         self.requires_runtime_license = self.cfg['requires_runtime_license'] and requires_runtime_license
 
         if self.requires_runtime_license:
-            license_file = self.cfg['license_file']
-            if (license_file is None) or isinstance(license_file, basestring):
-                license_specs = [license_file]
-            elif isinstance(license_file, (list, tuple)) and all(isinstance(x, basestring) for x in license_file):
-                license_specs = license_file
-            else:
-                msg = "Unsupported type %s for easyconfig parameter 'license_file'! " % type(license_file)
-                msg += "Can either be None, a string, or a tuple/list of strings."
-                raise EasyBuildError(msg)
-
             default_lic_env_var = 'INTEL_LICENSE_FILE'
+            license_specs = ensure_iterable_license_specs(self.cfg['license_file'])
             lic_specs, self.license_env_var = find_flexlm_license(custom_env_vars=[default_lic_env_var],
                                                                   lic_specs=license_specs)
 

--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -218,11 +218,11 @@ class IntelBase(EasyBlock):
             license_file = self.cfg['license_file']
             if (license_file is None) or isinstance(license_file, basestring):
                 license_specs = [license_file]
-            elif isinstance(license_file, list):
+            elif isinstance(license_file, (list, tuple)) and all(isinstance(x, basestring) for x in license_file):
                 license_specs = license_file
             else:
-                msg = "Unsupported type for easyconfig parameter 'license_file'! "
-                msg += "Can either be None, a string, or a list of strings."
+                msg = "Unsupported type %s for easyconfig parameter 'license_file'! " % type(license_file)
+                msg += "Can either be None, a string, or a tuple/list of strings."
                 raise EasyBuildError(msg)
 
             default_lic_env_var = 'INTEL_LICENSE_FILE'

--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -216,13 +216,13 @@ class IntelBase(EasyBlock):
 
         if self.requires_runtime_license:
             license_file = self.cfg['license_file']
-            if isinstance(license_file, basestring):
+            if (license_file is None) or isinstance(license_file, basestring):
                 license_specs = [license_file]
             elif isinstance(license_file, list):
                 license_specs = license_file
             else:
                 msg = "Unsupported type for easyconfig parameter 'license_file'! "
-                msg += "Can either be a string or a list of strings."
+                msg += "Can either be None, a string, or a list of strings."
                 raise EasyBuildError(msg)
 
             default_lic_env_var = 'INTEL_LICENSE_FILE'

--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -215,9 +215,19 @@ class IntelBase(EasyBlock):
         self.requires_runtime_license = self.cfg['requires_runtime_license'] and requires_runtime_license
 
         if self.requires_runtime_license:
+            license_file = self.cfg['license_file']
+            if isinstance(license_file, basestring):
+                license_specs = [license_file]
+            elif isinstance(license_file, list):
+                license_specs = license_file
+            else:
+                msg = "Unsupported type for easyconfig parameter 'license_file'! "
+                msg += "Can either be a string or a list of strings."
+                raise EasyBuildError(msg)
+
             default_lic_env_var = 'INTEL_LICENSE_FILE'
             lic_specs, self.license_env_var = find_flexlm_license(custom_env_vars=[default_lic_env_var],
-                                                                  lic_specs=[self.cfg['license_file']])
+                                                                  lic_specs=license_specs)
 
             if lic_specs:
                 if self.license_env_var is None:

--- a/easybuild/easyblocks/p/pgi.py
+++ b/easybuild/easyblocks/p/pgi.py
@@ -93,9 +93,19 @@ class EB_PGI(PackedBinary):
         """
         Handle license file.
         """
+        license_file = self.cfg['license_file']
+        if isinstance(license_file, basestring):
+            license_specs = [license_file]
+        elif isinstance(license_file, list):
+            license_specs = license_file
+        else:
+            msg = "Unsupported type for easyconfig parameter 'license_file'! "
+            msg += "Can either be a string or a list of strings."
+            raise EasyBuildError(msg)
+
         default_lic_env_var = 'PGROUPD_LICENSE_FILE'
         lic_specs, self.license_env_var = find_flexlm_license(custom_env_vars=[default_lic_env_var],
-                                                              lic_specs=[self.cfg['license_file']])
+                                                              lic_specs=license_specs)
 
         if lic_specs:
             if self.license_env_var is None:

--- a/easybuild/easyblocks/p/pgi.py
+++ b/easybuild/easyblocks/p/pgi.py
@@ -40,6 +40,7 @@ import sys
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.packedbinary import PackedBinary
 from easybuild.framework.easyconfig import CUSTOM
+from easybuild.framework.easyconfig.types import ensure_iterable_license_specs
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import find_flexlm_license, write_file
 from easybuild.tools.run import run_cmd
@@ -93,17 +94,8 @@ class EB_PGI(PackedBinary):
         """
         Handle license file.
         """
-        license_file = self.cfg['license_file']
-        if (license_file is None) or isinstance(license_file, basestring):
-            license_specs = [license_file]
-        elif isinstance(license_file, (list, tuple)) and all(isinstance(x, basestring) for x in license_file):
-            license_specs = license_file
-        else:
-            msg = "Unsupported type %s for easyconfig parameter 'license_file'! " % type(license_file)
-            msg += "Can either be None, a string, or a tuple/list of strings."
-            raise EasyBuildError(msg)
-
         default_lic_env_var = 'PGROUPD_LICENSE_FILE'
+        license_specs = ensure_iterable_license_specs(self.cfg['license_file'])
         lic_specs, self.license_env_var = find_flexlm_license(custom_env_vars=[default_lic_env_var],
                                                               lic_specs=license_specs)
 

--- a/easybuild/easyblocks/p/pgi.py
+++ b/easybuild/easyblocks/p/pgi.py
@@ -94,13 +94,13 @@ class EB_PGI(PackedBinary):
         Handle license file.
         """
         license_file = self.cfg['license_file']
-        if isinstance(license_file, basestring):
+        if (license_file is None) or isinstance(license_file, basestring):
             license_specs = [license_file]
         elif isinstance(license_file, list):
             license_specs = license_file
         else:
             msg = "Unsupported type for easyconfig parameter 'license_file'! "
-            msg += "Can either be a string or a list of strings."
+            msg += "Can either be None, a string, or a list of strings."
             raise EasyBuildError(msg)
 
         default_lic_env_var = 'PGROUPD_LICENSE_FILE'

--- a/easybuild/easyblocks/p/pgi.py
+++ b/easybuild/easyblocks/p/pgi.py
@@ -96,11 +96,11 @@ class EB_PGI(PackedBinary):
         license_file = self.cfg['license_file']
         if (license_file is None) or isinstance(license_file, basestring):
             license_specs = [license_file]
-        elif isinstance(license_file, list):
+        elif isinstance(license_file, (list, tuple)) and all(isinstance(x, basestring) for x in license_file):
             license_specs = license_file
         else:
-            msg = "Unsupported type for easyconfig parameter 'license_file'! "
-            msg += "Can either be None, a string, or a list of strings."
+            msg = "Unsupported type %s for easyconfig parameter 'license_file'! " % type(license_file)
+            msg += "Can either be None, a string, or a tuple/list of strings."
             raise EasyBuildError(msg)
 
         default_lic_env_var = 'PGROUPD_LICENSE_FILE'

--- a/easybuild/easyblocks/t/totalview.py
+++ b/easybuild/easyblocks/t/totalview.py
@@ -41,13 +41,13 @@ class EB_TotalView(PackedBinary):
         Handle of license
         """
         license_file = self.cfg['license_file']
-        if isinstance(license_file, basestring):
+        if (license_file is None) or isinstance(license_file, basestring):
             license_specs = [license_file]
         elif isinstance(license_file, list):
             license_specs = license_file
         else:
             msg = "Unsupported type for easyconfig parameter 'license_file'! "
-            msg += "Can either be a string or a list of strings."
+            msg += "Can either be None, a string, or a list of strings."
             raise EasyBuildError(msg)
 
         default_lic_env_var = 'LM_LICENSE_FILE'

--- a/easybuild/easyblocks/t/totalview.py
+++ b/easybuild/easyblocks/t/totalview.py
@@ -40,9 +40,19 @@ class EB_TotalView(PackedBinary):
         """
         Handle of license
         """
+        license_file = self.cfg['license_file']
+        if isinstance(license_file, basestring):
+            license_specs = [license_file]
+        elif isinstance(license_file, list):
+            license_specs = license_file
+        else:
+            msg = "Unsupported type for easyconfig parameter 'license_file'! "
+            msg += "Can either be a string or a list of strings."
+            raise EasyBuildError(msg)
+
         default_lic_env_var = 'LM_LICENSE_FILE'
         lic_specs, self.license_env_var = find_flexlm_license(custom_env_vars=[default_lic_env_var],
-                                                              lic_specs=[self.cfg['license_file']])
+                                                              lic_specs=license_specs)
 
         if lic_specs:
             if self.license_env_var is None:

--- a/easybuild/easyblocks/t/totalview.py
+++ b/easybuild/easyblocks/t/totalview.py
@@ -20,6 +20,7 @@ import os
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.packedbinary import PackedBinary
+from easybuild.framework.easyconfig.types import ensure_iterable_license_specs
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import find_flexlm_license
 from easybuild.tools.modules import get_software_root
@@ -40,17 +41,8 @@ class EB_TotalView(PackedBinary):
         """
         Handle of license
         """
-        license_file = self.cfg['license_file']
-        if (license_file is None) or isinstance(license_file, basestring):
-            license_specs = [license_file]
-        elif isinstance(license_file, (list, tuple)) and all(isinstance(x, basestring) for x in license_file):
-            license_specs = license_file
-        else:
-            msg = "Unsupported type %s for easyconfig parameter 'license_file'! " % type(license_file)
-            msg += "Can either be None, a string, or a tuple/list of strings."
-            raise EasyBuildError(msg)
-
         default_lic_env_var = 'LM_LICENSE_FILE'
+        license_specs = ensure_iterable_license_specs(self.cfg['license_file'])
         lic_specs, self.license_env_var = find_flexlm_license(custom_env_vars=[default_lic_env_var],
                                                               lic_specs=license_specs)
 

--- a/easybuild/easyblocks/t/totalview.py
+++ b/easybuild/easyblocks/t/totalview.py
@@ -43,11 +43,11 @@ class EB_TotalView(PackedBinary):
         license_file = self.cfg['license_file']
         if (license_file is None) or isinstance(license_file, basestring):
             license_specs = [license_file]
-        elif isinstance(license_file, list):
+        elif isinstance(license_file, (list, tuple)) and all(isinstance(x, basestring) for x in license_file):
             license_specs = license_file
         else:
-            msg = "Unsupported type for easyconfig parameter 'license_file'! "
-            msg += "Can either be None, a string, or a list of strings."
+            msg = "Unsupported type %s for easyconfig parameter 'license_file'! " % type(license_file)
+            msg += "Can either be None, a string, or a tuple/list of strings."
             raise EasyBuildError(msg)
 
         default_lic_env_var = 'LM_LICENSE_FILE'


### PR DESCRIPTION
So far, passing the license via the easyconfig parameter `license_file` only worked with a single file/server.  To set multiple files/servers, one had to define the corresponding environment variable before invoking `eb`.

**Edit:** Now requires https://github.com/hpcugent/easybuild-framework/pull/2157