### PR TITLE
modified trinity sanity check for versions 2.3 and above

### DIFF
--- a/easybuild/easyblocks/t/trinity.py
+++ b/easybuild/easyblocks/t/trinity.py
@@ -309,8 +309,10 @@ class EB_Trinity(EasyBlock):
         """Custom sanity check for Trinity."""
 
         version = LooseVersion(self.version)
-        if version >= LooseVersion('2.0') and version < LooseVersion('3.0'):
+        if version >= LooseVersion('2.0') and version < LooseVersion('2.3'):
             sep = '-'
+        elif version >= LooseVersion('2.3') and version < LooseVersion('3.0'):
+            sep = "-Trinity-v"
         else:
             sep = '_r'
 


### PR DESCRIPTION
In versions 2.3 and 2.4, the name of the folder has changed. Need to adjust the sanity check to take it into consideration. 