### PR TITLE
fix 'prefix' subdirectory for older versions of icc/ifort

### DIFF
--- a/easybuild/easyblocks/i/icc.py
+++ b/easybuild/easyblocks/i/icc.py
@@ -121,7 +121,9 @@ class EB_icc(IntelBase):
             'dirs': [],
         }
 
-        super(EB_icc, self).sanity_check_step(custom_paths=custom_paths)
+        custom_commands = ["which icc"]
+
+        super(EB_icc, self).sanity_check_step(custom_paths=custom_paths, custom_commands=custom_commands)
 
     def make_module_req_guess(self):
         """
@@ -173,11 +175,11 @@ class EB_icc(IntelBase):
             ])
 
             if LooseVersion(self.version) < LooseVersion('2016'):
-                prefix = 'composer-xe-%s' % self.version
+                prefix = 'composer_xe_%s' % self.version
 
                 # debugger is dependent on $INTEL_PYTHONHOME since version 2015 and newer
                 if LooseVersion(self.version) >= LooseVersion('2015'):
-                    self.debuggerpath = os.path.join('composer-xe-%s' % self.version.split('.')[0], 'debugger')
+                    self.debuggerpath = os.path.join(prefix, 'debugger')
 
             else:
                 # new directory layout for Intel Parallel Studio XE 2016

--- a/easybuild/easyblocks/i/ifort.py
+++ b/easybuild/easyblocks/i/ifort.py
@@ -72,4 +72,7 @@ class EB_ifort(EB_icc, IntelBase):
             'files': [os.path.join(binprefix, x) for x in bins] + [os.path.join(libprefix, 'lib%s' % l) for l in libs],
             'dirs': [],
         }
-        IntelBase.sanity_check_step(self, custom_paths=custom_paths)
+
+        custom_commands = ["which ifort"]
+
+        IntelBase.sanity_check_step(self, custom_paths=custom_paths, custom_commands=custom_commands)


### PR DESCRIPTION
also add '`which <compilername>`' as sanity check command


fix for bug introduced in #1126, where the subdirectory where `icc` and `ifort` was no longer included in `$PATH` for versions where `bin/intel64` does not exist but `composer_xe_<version>/bin/intel64` does, which includes versions 2013_sp* and 2015.*...

the value for `prefix` was wrong all along, but this was never noticed since the non-prefixed subdirectories were also being included, including `bin`

serves me right for doing last-minute merges ;)

cc @bartoldeman 