### PR TITLE
enhance Bowtie2 easyblock: set correct build options, copy more files, extend sanity check

### DIFF
--- a/easybuild/easyblocks/b/bowtie2.py
+++ b/easybuild/easyblocks/b/bowtie2.py
@@ -16,12 +16,13 @@ EasyBuild support for building and installing Bowtie2, implemented as an easyblo
 @author: Fotis Georgatos (Uni.Lu)
 @author: Kenneth Hoste (Ghent University)
 """
-
+from distutils.version import LooseVersion
 import os
 import shutil
 
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.filetools import copy_file
 
 
 class EB_Bowtie2(ConfigureMake):
@@ -30,35 +31,60 @@ class EB_Bowtie2(ConfigureMake):
     - create Make.UNKNOWN
     - build with make and install 
     """
+    def __init__(self, *args, **kwargs):
+        """Bowtie2 easyblock constructor, define class variables."""
+        super(EB_Bowtie2, self).__init__(*args, **kwargs)
+
+        self.bowtie2_files = ['bowtie2', 'bowtie2-build', 'bowtie2-inspect', 'MANUAL', 'MANUAL.markdown', 'NEWS']
+        if LooseVersion(self.version) >= LooseVersion('2.2.0'):
+            self.bowtie2_files.extend(['bowtie2-align-l', 'bowtie2-align-s', 'bowtie2-build-l', 'bowtie2-build-s',
+                                       'bowtie2-inspect-l', 'bowtie2-inspect-s'])
+        else:
+            self.bowtie2_files.extend(['bowtie2-align'])
+
+        if LooseVersion(self.version) >= LooseVersion('2.0.5'):
+            self.bowtie2_files.append('LICENSE')
 
     def configure_step(self):
-        """
-        Empty function as bowtie2 comes with _no_ configure script
-        """
+        """No custom configuration step for Bowtie2"""
         pass
+
+    def build_step(self):
+        """Build Bowtie2, make sure right compilation flags are used"""
+
+        cc = os.getenv('CC')
+        if cc:
+            self.cfg.update('buildopts', 'CC="%s"' % cc)
+
+        cxx = os.getenv('CXX')
+        if cxx:
+            self.cfg.update('buildopts', 'CPP="%s" CXX="%s"' % (cxx, cxx))
+
+        cxxflags = os.getenv('CXXFLAGS')
+        if cxxflags:
+            self.cfg.update('buildopts', 'RELEASE_FLAGS="%s"' % cxxflags)
+
+        super(EB_Bowtie2, self).build_step()
 
     def install_step(self):
         """
         Install by copying files to install dir
         """
-        srcdir = self.cfg['start_dir']
-        destdir = os.path.join(self.installdir, 'bin')
-        srcfile = None
-        try:
-            os.makedirs(destdir)
-            for filename in ["bowtie2", "bowtie2-align", "bowtie2-build", "bowtie2-inspect"]:
-                srcfile = os.path.join(srcdir, filename)
-                shutil.copy2(srcfile, destdir)
-        except OSError, err:
-            raise EasyBuildError("Copying %s to installation dir %s failed: %s", srcfile, destdir, err)
+        for filename in self.bowtie2_files:
+            copy_file(os.path.join(self.cfg['start_dir'], filename), os.path.join(self.installdir, 'bin', filename))
+
+        for dirname in ['doc', 'example', 'scripts']:
+            srcdir = os.path.join(self.cfg['start_dir'], dirname)
+            targetdir = os.path.join(self.installdir, dirname)
+            try:
+                shutil.copytree(srcdir, targetdir)
+            except OSError as err:
+                raise EasyBuildError("Failed to copy %s directory to %s: %s", srcdir, targetdir, err)
 
     def sanity_check_step(self):
         """Custom sanity check for Bowtie2."""
-
         custom_paths = {
-                        'files': ['bin/bowtie2', 'bin/bowtie2-align', 'bin/bowtie2-build', 'bin/bowtie2-inspect' ],
-                        'dirs': ['.']
-                       }
-
+            'files': [os.path.join('bin', f) for f in self.bowtie2_files],
+            'dirs': ['doc', 'example', 'scripts']
+        }
         super(EB_Bowtie2, self).sanity_check_step(custom_paths=custom_paths)
-


### PR DESCRIPTION
Triggered by addition of `RELEASE_FLAGS` in `buildopts` by @klust in https://github.com/hpcugent/easybuild-easyconfigs/pull/4372

This makes the Bowtie2 installations across toolchains consistent, and allows to clean up the Bowtie2 easyconfigs significantly (cfr. https://github.com/hpcugent/easybuild-easyconfigs/pull/4380)