### PR TITLE
allow libpng as OS dependency for WPS

### DIFF
--- a/easybuild/easyblocks/w/wps.py
+++ b/easybuild/easyblocks/w/wps.py
@@ -110,6 +110,8 @@ class EB_WPS(EasyBlock):
         # libpng dependency check
         libpng = get_software_root('libpng')
         zlib = get_software_root('zlib')
+        libpnglib = ""
+        libpnginc = ""
         if libpng:
             paths = [libpng]
             if zlib:

--- a/easybuild/easyblocks/w/wps.py
+++ b/easybuild/easyblocks/w/wps.py
@@ -116,8 +116,6 @@ class EB_WPS(EasyBlock):
                 paths.insert(0, zlib)
             libpnginc = ' '.join(['-I%s' % os.path.join(path, 'include') for path in paths])
             libpnglib = ' '.join(['-L%s' % os.path.join(path, 'lib') for path in paths])
-        else:
-            raise EasyBuildError("libpng module not loaded?")
 
         # JasPer dependency check + setting env vars
         jasper = get_software_root('JasPer')

--- a/easybuild/easyblocks/w/wps.py
+++ b/easybuild/easyblocks/w/wps.py
@@ -110,14 +110,16 @@ class EB_WPS(EasyBlock):
         # libpng dependency check
         libpng = get_software_root('libpng')
         zlib = get_software_root('zlib')
-        libpnglib = ""
-        libpnginc = ""
         if libpng:
             paths = [libpng]
             if zlib:
                 paths.insert(0, zlib)
             libpnginc = ' '.join(['-I%s' % os.path.join(path, 'include') for path in paths])
             libpnglib = ' '.join(['-L%s' % os.path.join(path, 'lib') for path in paths])
+        else:
+            # define these as empty, assume that libpng will be available via OS (e.g. due to --filter-deps=libpng)
+            libpnglib = ""
+            libpnginc = ""
 
         # JasPer dependency check + setting env vars
         jasper = get_software_root('JasPer')


### PR DESCRIPTION
Need to define libpnglib and libpnginc to an empty value first, because they are used later. If the libpng and zlib are not found as module, expect to have them find as an OS package. 