### PR TITLE
Extending Boost TIME_UTC patch to Boost versions <= 1.49.0

### DIFF
--- a/easybuild/easyblocks/b/boost.py
+++ b/easybuild/easyblocks/b/boost.py
@@ -79,10 +79,10 @@ class EB_Boost(EasyBlock):
         """Patch Boost source code before building."""
         super(EB_Boost, self).patch_step()
 
-        # TIME_UTC is also defined in recent glibc versions, so we need to rename it for old Boost versions (<= 1.47)
+        # TIME_UTC is also defined in recent glibc versions, so we need to rename it for old Boost versions (<= 1.49)
         glibc_version = get_glibc_version()
         old_glibc = glibc_version is not UNKNOWN and LooseVersion(glibc_version) > LooseVersion("2.15")
-        if old_glibc and LooseVersion(self.version) <= LooseVersion("1.47.0"):
+        if old_glibc and LooseVersion(self.version) <= LooseVersion("1.49.0"):
             self.log.info("Patching because the glibc version is too new")
             files_to_patch = ["boost/thread/xtime.hpp"] + glob.glob("libs/interprocess/test/*.hpp")
             files_to_patch += glob.glob("libs/spirit/classic/test/*.cpp") + glob.glob("libs/spirit/classic/test/*.inl")


### PR DESCRIPTION
Applies the Boost TIME_UTC patch to versions <= 1.49.0 instead of just versions <= 1.47.0 due to the actual fix not being implemented in Boost until version 1.50.0, from #1151 

edit: fixes errors like shown below for Boost 1.49.0

```
In file included from ./boost/thread/pthread/mutex.hpp:14:0,
                 from ./boost/thread/mutex.hpp:16,
                 from ./boost/thread/pthread/thread_data.hpp:12,
                 from ./boost/thread/thread.hpp:17,
                 from libs/thread/src/pthread/thread.cpp:10:
./boost/thread/xtime.hpp:23:5: error: expected identifier before numeric constant
./boost/thread/xtime.hpp:23:5: error: expected ‘}’ before numeric constant
./boost/thread/xtime.hpp:23:5: error: expected unqualified-id before numeric constant
./boost/thread/xtime.hpp:46:14: error: expected type-specifier before ‘system_time’
```