### PR TITLE
Preinstallopts for binary and packed binary easyblocks

### DIFF
--- a/easybuild/easyblocks/generic/binary.py
+++ b/easybuild/easyblocks/generic/binary.py
@@ -98,6 +98,11 @@ class Binary(EasyBlock):
         """Copy all files in build directory to the install directory"""
         if self.cfg['install_cmd'] is None:
             try:
+                cmd = self.cfg['preinstallopts']
+                if cmd:
+                    self.log.info("Running preinstallopts of %s using command '%s'..." % (self.name, cmd))
+                    run_cmd(cmd, log_all=True, simple=True)
+                self.log.info("Copying %s into '%s'..." % (self.cfg['start_dir'], self.installdir))
                 # shutil.copytree doesn't allow the target directory to exist already
                 rmtree2(self.installdir)
                 shutil.copytree(self.cfg['start_dir'], self.installdir, symlinks=self.cfg['keepsymlinks'])

--- a/easybuild/easyblocks/generic/packedbinary.py
+++ b/easybuild/easyblocks/generic/packedbinary.py
@@ -33,6 +33,7 @@ import shutil
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.easyblocks.generic.binary import Binary
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.run import run_cmd
 
 
 class PackedBinary(Binary, EasyBlock):
@@ -46,6 +47,12 @@ class PackedBinary(Binary, EasyBlock):
 
     def install_step(self):
         """Copy all unpacked source directories to install directory, one-by-one."""
+        cmd = self.cfg['preinstallopts']
+        if cmd:
+            self.log.info("Running preinstallopts of %s using command '%s'..." % (self.name, cmd))
+            run_cmd(cmd, log_all=True, simple=True)
+            self.cfg['preinstallopts'] = None
+
         try:
             os.chdir(self.builddir)
             for src in os.listdir(self.builddir):


### PR DESCRIPTION
These easyblocks were missing (and silently ignoring) preinstallopts. It might be necessary to delete stuff prior to copying to the installation directory. Of course it can be done too with `postinstallcmds`, but this option can affect the module generator for instance, if the library dir is deleted.