### PR TITLE
Fix problems when usempi not defined in toolchain

### DIFF
--- a/easybuild/easyblocks/n/namd.py
+++ b/easybuild/easyblocks/n/namd.py
@@ -59,7 +59,7 @@ class EB_NAMD(MakeCp):
 
         # complete Charm ++ and NAMD architecture string with compiler family
         comp_fam = self.toolchain.comp_family()
-        if self.toolchain.options['usempi']:
+        if 'usempi' in self.toolchain.options and self.toolchain.options['usempi']:
             charm_arch_comp = 'mpicxx'
         else:
             charm_arch_comps = {

--- a/easybuild/easyblocks/n/namd.py
+++ b/easybuild/easyblocks/n/namd.py
@@ -59,7 +59,7 @@ class EB_NAMD(MakeCp):
 
         # complete Charm ++ and NAMD architecture string with compiler family
         comp_fam = self.toolchain.comp_family()
-        if 'usempi' in self.toolchain.options and self.toolchain.options['usempi']:
+        if self.toolchain.options.get('usempi', False):
             charm_arch_comp = 'mpicxx'
         else:
             charm_arch_comps = {


### PR DESCRIPTION
Many common build configurations of NAMD do not use MPI.  This change makes namd.py work with toolchains without MPI.