### PR TITLE
revert building in parallel for NCL, enhance sanity check

### DIFF
--- a/easybuild/easyblocks/n/ncl.py
+++ b/easybuild/easyblocks/n/ncl.py
@@ -202,8 +202,8 @@ class EB_NCL(EasyBlock):
         Custom sanity check for NCL
         """
         custom_paths = {
-            'files': ["bin/ncl", "lib/libncl.a", "lib/libncarg.a"],
-            'dirs': ["include/ncarg"],
+            'files': ['bin/fontc', 'bin/ncl', 'lib/libncl.a', 'lib/libncarg.a'],
+            'dirs': ['include/ncarg', 'lib/ncarg/fontcaps'],
         }
         super(EB_NCL, self).sanity_check_step(custom_paths=custom_paths)
 

--- a/easybuild/easyblocks/n/ncl.py
+++ b/easybuild/easyblocks/n/ncl.py
@@ -193,11 +193,9 @@ class EB_NCL(EasyBlock):
 
     def install_step(self):
         """Build in install dir using build_step."""
-        paracmd = ''
-        if self.cfg['parallel']:
-            paracmd = "-j %s" % self.cfg['parallel']
 
-        run_cmd("make %s Everything" % paracmd, log_all=True, simple=True)
+        cmd = "make Everything"
+        run_cmd(cmd, log_all=True, simple=True)
 
     def sanity_check_step(self):
         """


### PR DESCRIPTION
building in parallel was enabled in #1169, but it turns out this break the installation in subtle ways, i.e. fonts are no longer being found when generating plots with NCL (using `ng4ex gsun01n -clean`) because the installation is incomplete (`fontcaps` failed to build)

cc @akesandgren