### PR TITLE
updated for MATLAB 2017a

### DIFF
--- a/easybuild/easyblocks/m/matlab.py
+++ b/easybuild/easyblocks/m/matlab.py
@@ -114,7 +114,6 @@ class EB_MATLAB(PackedBinary):
             for perm_dir in [os.path.join(self.cfg['start_dir'], 'bin', 'glnxa64'), jdir]:
                 adjust_permissions(perm_dir, stat.S_IXUSR)
 
-
         # make sure $DISPLAY is not defined, which may lead to (hard to trace) problems
         # this is a workaround for not being able to specify --nodisplay to the install scripts
         if 'DISPLAY' in os.environ:

--- a/easybuild/easyblocks/m/matlab.py
+++ b/easybuild/easyblocks/m/matlab.py
@@ -42,7 +42,7 @@ from distutils.version import LooseVersion
 from easybuild.easyblocks.generic.packedbinary import PackedBinary
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import adjust_permissions, read_file, write_file
+from easybuild.tools.filetools import adjust_permissions, change_dir, read_file, write_file
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
 
@@ -122,7 +122,7 @@ class EB_MATLAB(PackedBinary):
         if not '_JAVA_OPTIONS' in self.cfg['preinstallopts']:
             self.cfg['preinstallopts'] = ('export _JAVA_OPTIONS="%s" && ' % self.cfg['java_options']) + self.cfg['preinstallopts']
         if LooseVersion(self.version) >= LooseVersion('2017a'):
-            run_cmd('cd %s' % self.builddir, log_all=True, simple=True)
+            change_dir(self.builddir)
 
         cmd = "%s %s -v -inputFile %s %s" % (self.cfg['preinstallopts'], src, self.configfile, self.cfg['installopts'])
         run_cmd(cmd, log_all=True, simple=True)

--- a/easybuild/easyblocks/m/matlab.py
+++ b/easybuild/easyblocks/m/matlab.py
@@ -111,8 +111,8 @@ class EB_MATLAB(PackedBinary):
 
         if LooseVersion(self.version) >= LooseVersion('2017a'):
             jdir = os.path.join(self.cfg['start_dir'], 'sys', 'java', 'jre', 'glnxa64', 'jre', 'bin')
-            for perm_file in [os.path.join(self.cfg['start_dir'], 'bin', 'glnxa64'), jdir]:
-                adjust_permissions(perm_file, stat.S_IXUSR)
+            for perm_dir in [os.path.join(self.cfg['start_dir'], 'bin', 'glnxa64'), jdir]:
+                adjust_permissions(perm_dir, stat.S_IXUSR)
 
 
         # make sure $DISPLAY is not defined, which may lead to (hard to trace) problems

--- a/easybuild/easyblocks/m/matlab.py
+++ b/easybuild/easyblocks/m/matlab.py
@@ -122,14 +122,10 @@ class EB_MATLAB(PackedBinary):
 
         if not '_JAVA_OPTIONS' in self.cfg['preinstallopts']:
             self.cfg['preinstallopts'] = ('export _JAVA_OPTIONS="%s" && ' % self.cfg['java_options']) + self.cfg['preinstallopts']
-        chdircmd = ' '
-        installerpath = '.'
         if LooseVersion(self.version) >= LooseVersion('2017a'):
-            chdircmd = 'cd %s &&' % self.builddir 
-            installerpath = self.cfg['start_dir']
+            run_cmd('cd %s' % self.builddir, log_all=True, simple=True)
 
-        cmd = "%s %s %s/install -v -inputFile %s %s" % (self.cfg['preinstallopts'], chdircmd, installerpath, self.configfile,
-                                                        self.cfg['installopts'])
+        cmd = "%s %s -v -inputFile %s %s" % (self.cfg['preinstallopts'], src, self.configfile, self.cfg['installopts'])
         run_cmd(cmd, log_all=True, simple=True)
 
     def sanity_check_step(self):


### PR DESCRIPTION
Matlab 2017a install complains that you should not run the installed from the root directory of install CD. 