### PR TITLE
stop using deprecated 'copytree' function from easybuild.tools.filetools

### DIFF
--- a/easybuild/easyblocks/d/dl_poly_classic.py
+++ b/easybuild/easyblocks/d/dl_poly_classic.py
@@ -33,7 +33,7 @@ import os
 import shutil
 
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import copy_file, copytree
+from easybuild.tools.filetools import copy_file, copy_dir
 from easybuild.tools.run import run_cmd
 from easybuild.easyblocks.generic.configuremake import ConfigureMake
 
@@ -101,7 +101,7 @@ class EB_DL_underscore_POLY_underscore_Classic(ConfigureMake):
         # create a 'bin' subdir, this way we also get $PATH to be set correctly automatically
         install_path = os.path.join(self.cfg['start_dir'], 'execute')
         bin_path = os.path.join(self.installdir, 'bin')
-        copytree(install_path, bin_path)
+        copy_dir(install_path, bin_path)
 
     def sanity_check_step(self):
         """Custom sanity check step for DL_POLY Classic"""

--- a/easybuild/easyblocks/s/scotch.py
+++ b/easybuild/easyblocks/s/scotch.py
@@ -34,15 +34,14 @@ EasyBuild support for SCOTCH, implemented as an easyblock
 import fileinput
 import os
 import re
-import sys
 import shutil
+import sys
 from distutils.version import LooseVersion
 
 import easybuild.tools.toolchain as toolchain
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import copytree
 from easybuild.tools.run import run_cmd
 
 
@@ -144,7 +143,7 @@ class EB_SCOTCH(EasyBlock):
                 src = os.path.join(self.cfg['start_dir'], d)
                 dst = os.path.join(self.installdir, d)
                 # we don't need any metis stuff from scotch!
-                copytree(src, dst, ignore=lambda path, files: [x for x in files if regmetis.match(x)])
+                shutil.copytree(src, dst, ignore=lambda path, files: [x for x in files if regmetis.match(x)])
 
         except OSError, err:
             raise EasyBuildError("Copying %s to installation dir %s failed: %s", src, dst, err)


### PR DESCRIPTION
`copytree` function was deprecated in https://github.com/hpcugent/easybuild-framework/pull/2177

`copy_dir` is not a drop-in replacement yet for (`shutil.`)`copytree`, at least not without https://github.com/hpcugent/easybuild-framework/pull/2230

Once https://github.com/hpcugent/easybuild-framework/pull/2230 is merged, I plan to get rid of all `shutil.copytree` uses in the existing easyblocks.