### PR TITLE
Fixed bug in alias definition in IMPI

### DIFF
--- a/easybuild/easyblocks/i/impi.py
+++ b/easybuild/easyblocks/i/impi.py
@@ -217,12 +217,13 @@ EULA=accept
         if self.cfg['set_mpi_wrapper_aliases_gcc'] or self.cfg['set_mpi_wrappers_all']:
             # force mpigcc/mpigxx to use GCC compilers, as would be expected based on their name
             txt += self.module_generator.set_alias('mpigcc', 'mpigcc -cc=gcc')
-            txt += self.module_generator.set_alias('mpigxx', 'mpigxx -cc=g++')
+            txt += self.module_generator.set_alias('mpigxx', 'mpigxx -cxx=g++')
 
         if self.cfg['set_mpi_wrapper_aliases_intel'] or self.cfg['set_mpi_wrappers_all']:
             # do the same for mpiicc/mpiipc/mpiifort to be consistent, even if they may not exist
             txt += self.module_generator.set_alias('mpiicc', 'mpiicc -cc=icc')
-            txt += self.module_generator.set_alias('mpiicpc', 'mpiicpc -cc=icpc')
-            txt += self.module_generator.set_alias('mpiifort', 'mpiifort -cc=ifort')
+            txt += self.module_generator.set_alias('mpiicpc', 'mpiicpc -cxx=icpc')
+            # -fc also works, but -f90 takes precedence
+            txt += self.module_generator.set_alias('mpiifort', 'mpiifort -f90=ifort')
 
         return txt


### PR DESCRIPTION
The alias definition in `impi.py` is wrong. It uses `-cc` for the C++ and Fortran wrappers, which need `-cxx` and `[-f90|-fc]` instead. Example:

```
~]$ $EBROOTIMPI/bin64/mpiicpc -cxx=not_existing_compiler -show
not_existing_compiler [...]

~]$ $EBROOTIMPI/bin64/mpiicpc -cc=not_existing_compiler -show
icpc '-cc=not_existing_compiler' [...]
```