### PR TITLE
consider $EB_*_LICENSE_SERVER(_PORT) in MATLAB and ANSYS easyblocks

### DIFF
--- a/easybuild/easyblocks/a/ansys.py
+++ b/easybuild/easyblocks/a/ansys.py
@@ -47,7 +47,11 @@ class EB_ANSYS(PackedBinary):
     def install_step(self):
         """Custom install procedure for ANSYS."""
         licserv = self.cfg['license_server']
+        if licserv is None:
+            licserv = os.getenv('EB_ANSYS_LICENSE_SERVER', 'license.example.com')
         licport = self.cfg['license_server_port']
+        if licport is None:
+            licport = os.getenv('EB_ANSYS_LICENSE_SERVER_PORT', '2325:1055')
 
         cmd = "./INSTALL -silent -install_dir %s -licserverinfo %s:%s" % (self.installdir, licport, licserv)
         run_cmd(cmd, log_all=True, simple=True)

--- a/easybuild/easyblocks/m/matlab.py
+++ b/easybuild/easyblocks/m/matlab.py
@@ -97,7 +97,6 @@ class EB_MATLAB(PackedBinary):
             reglicpath = re.compile(r"^# licensePath=.*", re.M)
 
             config = regdest.sub("destinationFolder=%s" % self.installdir, config)
-            key = self.cfg['key']
             config = regkey.sub("fileInstallationKey=%s" % key, config)
             config = regagree.sub("agreeToLicense=Yes", config)
             config = regmode.sub("mode=silent", config)

--- a/easybuild/easyblocks/m/matlab.py
+++ b/easybuild/easyblocks/m/matlab.py
@@ -66,9 +66,18 @@ class EB_MATLAB(PackedBinary):
     def configure_step(self):
         """Configure MATLAB installation: create license file."""
 
-        # create license file
         licserv = self.cfg['license_server']
+        if licserv is None:
+            licserv = os.getenv('EB_MATLAB_LICENSE_SERVER', 'license.example.com')
         licport = self.cfg['license_server_port']
+        if licport is None:
+            licport = os.getenv('EB_MATLAB_LICENSE_SERVER_PORT', '00000')
+
+        key = self.cfg['key']
+        if key is None:
+            key = os.getenv('EB_MATLAB_KEY', '00000-00000-00000-00000-00000-00000-00000-00000-00000-00000')
+
+        # create license file
         lictxt = '\n'.join([
             "SERVER %s 000000000000 %s" % (licserv, licport),
             "USE_SERVER",


### PR DESCRIPTION
Currently the easyconfigs for ANSYS and MATLAB pick up on the `$EB_*_LICENSE_SERVER(_PORT)` environment variables, see https://github.com/hpcugent/easybuild-easyconfigs/pull/4762.

That's useful as a fallback mechanism so you can set these environment variables without touching the easyconfig files (mainly useful during testing), but since it requires an `import` statement in the easyconfig files, this should be handled by the easyblocks instead.

